### PR TITLE
Fixed compilation problem when building libmysofa.a

### DIFF
--- a/src/hrtf/tools.h
+++ b/src/hrtf/tools.h
@@ -30,7 +30,7 @@ void addArrayWeighted(float *dst, float *src, int size, float w);
 void scaleArray(float *dst, int size, float w);
 float loudness(float *in, int size);
 
-void nsearch(const void *key, const void *base, size_t num, size_t size,
+void nsearch(const void *key, const char *base, size_t num, size_t size,
 		int (*cmp)(const void *key, const void *elt), int *lower, int *higher);
 
 #endif /* SRC_TOOLS_H_ */


### PR DESCRIPTION
If you would rather leave it as const void *base, then we can change the tools.c declaration to be void instead of char. Either way, the method declarations weren't matching up and causing a compilation problem.