### PR TITLE
Fixed filter length parameter not getting filled in mysofa_open

### DIFF
--- a/src/hdf/dataobject.c
+++ b/src/hdf/dataobject.c
@@ -554,7 +554,7 @@ int readDataVar(struct READER *reader, struct DATAOBJECT *data,
 			strcat(data->string, ",");
 			strcat(data->string, buffer);
 		} else {
-			data->string = _strdup(buffer);
+			data->string = strdup(buffer);
 		}
 		break;
 

--- a/src/hrtf/cache.c
+++ b/src/hrtf/cache.c
@@ -73,7 +73,7 @@ struct MYSOFA_EASY *mysofa_cache_store(struct MYSOFA_EASY *easy, const char *fil
 	}
 	p->next = cache;
 	p->samplerate = samplerate;
-	p->filename = _strdup(filename);
+	p->filename = strdup(filename);
 	if(p->filename == NULL) {
 		free(p);
 		pthread_mutex_unlock(&mutex);

--- a/src/hrtf/easy.c
+++ b/src/hrtf/easy.c
@@ -61,6 +61,8 @@ struct MYSOFA_EASY* mysofa_open(const char *filename, float samplerate, int *fil
 	easy->neighborhood = mysofa_neighborhood_init(easy->hrtf,
 			easy->lookup);
 
+    *filterlength = easy->hrtf->N;
+
 	return easy;
 }
 

--- a/src/hrtf/tools.c
+++ b/src/hrtf/tools.c
@@ -26,7 +26,7 @@ int changeAttribute(struct MYSOFA_ATTRIBUTE *attr, char *name, char *value,
 		if (!strcmp(name, attr->name)
 				&& (value == NULL || !strcmp(value, attr->value))) {
 			free(attr->value);
-			attr->value = _strdup(newvalue);
+			attr->value = strdup(newvalue);
 			return 1;
 		}
 		attr = attr->next;


### PR DESCRIPTION
In the method mysofa_open, the filterlength parameter was never getting set so I added a line of code so that it gets set before the method returns. I also changed _strdup to strdup since _strdup does not exist in Linux despite Visual C's warning that you should use _strdup instead of strdup. With these changes, libmysofa seems to be working fine on Linux machines.