### PR TITLE
cache: remove pthread mutexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ If you need an Debian package, call
 
 ## Usage 
 
-Libmysofa has a few main function calls.
+Libmysofa has a few main function calls.  
+If your program is using several threads, you must use appropriate synchronisation mechanisms so only a single thread can access the library at a given time.
 
 To read a SOFA file call 
 


### PR DESCRIPTION
State in the documentation that appropriate synchronisation mechanisms
must be used in the calling functions.