### PR TITLE
Link against mysofa-static library instead of hardcoded .a path

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,7 +32,7 @@ install(FILES hrtf/mysofa.h DESTINATION include)
 
 if(BUILD_TESTS)
     add_executable(mysofa2json tests/sofa2json.c tests/json.c )
-    target_link_libraries (mysofa2json ${CMAKE_SOURCE_DIR}/build/src/libmysofa.a m z)
+    target_link_libraries (mysofa2json mysofa-static m z)
 
     add_executable(tests tests/tests.c tests/tools.c tests/check.c tests/lookup.c tests/neighbors.c tests/interpolate.c tests/resample.c tests/loudness.c
       tests/minphase.c tests/easy.c tests/cache.c tests/json.c)


### PR DESCRIPTION
Using the hardcoded .a file path there results in two major problems:
You are forced to build in the provided build dir, nowhere else works, no out of tree builds, no in-source build, no diffrently named build dir.
Additionally, not using the target for linking results in a missing dependency on it, so a plain make fails, because it tried to build mysofa2json first, before the static library is created or even built.

Just putting the mysofa-static target name there will make cmake figure out the correct .a path, and will set an appropriate dependency to ensure make builds things in order.