### PR TITLE
indentation rules for emacs

### DIFF
--- a/src/.dir-locals.el
+++ b/src/.dir-locals.el
@@ -1,0 +1,3 @@
+((nil . ((indent-tabs-mode . t)
+         (fill-column . 80)))
+ (c-mode . ((c-file-style . "BSD"))))


### PR DESCRIPTION
this is a simple [emacs per-dir configuration](https://www.gnu.org/software/emacs/manual/html_node/emacs/Directory-Variables.html) to set the indentation to <kbd>Tab</kbd>.

probably a better alternative might be to use [EditorConfig](http://editorconfig.org/), which is *cross-editor*....