### PR TITLE
added flag to apply loudness norm. or not at hrir import in mysofa_load

### DIFF
--- a/src/hrtf/easy.c
+++ b/src/hrtf/easy.c
@@ -15,7 +15,7 @@
  *
  */
 
-MYSOFA_EXPORT struct MYSOFA_EASY* mysofa_open(const char *filename, float samplerate, int *filterlength, int *err)
+MYSOFA_EXPORT struct MYSOFA_EASY* mysofa_open(const char *filename, float samplerate, int *filterlength, bool normalizeLoudness, int *err)
 {
 	struct MYSOFA_EASY *easy = malloc(sizeof(struct MYSOFA_EASY));
 	if(!easy) {
@@ -44,7 +44,9 @@ MYSOFA_EXPORT struct MYSOFA_EASY* mysofa_open(const char *filename, float sample
 		return NULL;
 	}
 
-	mysofa_loudness(easy->hrtf);
+	if (normalizeLoudness){
+		mysofa_loudness(easy->hrtf);
+	}
 
 /* does not sound well:
    mysofa_minphase(easy->hrtf,0.01);
@@ -67,14 +69,14 @@ MYSOFA_EXPORT struct MYSOFA_EASY* mysofa_open(const char *filename, float sample
 	return easy;
 }
 
-MYSOFA_EXPORT struct MYSOFA_EASY* mysofa_open_cached(const char *filename, float samplerate, int *filterlength, int *err)
+MYSOFA_EXPORT struct MYSOFA_EASY* mysofa_open_cached(const char *filename, float samplerate, int *filterlength, bool normalizeLoudness, int *err)
 {
 	struct MYSOFA_EASY* res = mysofa_cache_lookup(filename, samplerate);
 	if(res) {
 		*filterlength = res->hrtf->N;
 		return res;
 	}
-	res = mysofa_open(filename,samplerate,filterlength,err);
+	res = mysofa_open(filename,samplerate,filterlength,normalizeLoudness,err);
 	if(res) {
 		res = mysofa_cache_store(res,filename,samplerate);
 	}

--- a/src/hrtf/mysofa.h
+++ b/src/hrtf/mysofa.h
@@ -11,6 +11,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <stdbool.h>
 
 /** attributes */
 	struct MYSOFA_ATTRIBUTE {
@@ -124,8 +125,8 @@ extern "C" {
 		struct MYSOFA_NEIGHBORHOOD *neighborhood;
 	};
 
-	struct MYSOFA_EASY* mysofa_open(const char *filename, float samplerate, int *filterlength, int *err);
-	struct MYSOFA_EASY* mysofa_open_cached(const char *filename, float samplerate, int *filterlength, int *err);
+	struct MYSOFA_EASY* mysofa_open(const char *filename, float samplerate, int *filterlength, bool normalizeLoudness, int *err);
+	struct MYSOFA_EASY* mysofa_open_cached(const char *filename, float samplerate, int *filterlength, bool normalizeLoudness, int *err);
 	void mysofa_getfilter_short(struct MYSOFA_EASY* easy, float x, float y, float z,
 				    short *IRleft, short *IRright,
 				    int *delayLeft, int *delayRight);

--- a/src/tests/easy.c
+++ b/src/tests/easy.c
@@ -28,8 +28,9 @@ void test_easy() {
 	float c[3];
 	float l1,l2;
 	float sdiff1, sdiff2, diff1, diff2;
+	bool normalizeLoudness = true;
 
-	easy = mysofa_open("share/MIT_KEMAR_normal_pinna.sofa", 8000., &filterlength, &err);
+	easy = mysofa_open("share/MIT_KEMAR_normal_pinna.sofa", 8000., &filterlength, normalizeLoudness, &err);
 	if (!easy) {
 		CU_FAIL_FATAL("Error reading file.");
 		return;
@@ -37,7 +38,7 @@ void test_easy() {
 
 	mysofa_close(easy);
 
-	easy = mysofa_open("tests/tester.sofa", 48000, &filterlength, &err);
+	easy = mysofa_open("tests/tester.sofa", 48000, &filterlength, normalizeLoudness, &err);
 	if (!easy) {
 		CU_FAIL_FATAL("Error reading file.");
 		return;


### PR DESCRIPTION
I needed that flag to avoid normalisation when using libmysofa to load directivity patterns. I know it's not a typical use scenario, and that change in the API may mess with libs relying on libmysofa (can't define default argument in C method..).