### PR TITLE
Use /bin/sh instead of /bin/bash in tests

### DIFF
--- a/tests/compare.sh
+++ b/tests/compare.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/sh
 
 NODEJS=`which node || which nodejs || which false`
 ../build/src/mysofa2json "$1".sofa >tmp1.json 2>tmp1.txt 


### PR DESCRIPTION
/bin/bash is not guaranteed to exist on non-GNU systems, which may
place bash in /usr/local/bin or may not provide it at all. This
script does not use any bash-specific features, so the easiest
solution here is to simply use /bin/sh, which is ubiquitous on
Unix.