### PR TITLE
modified lib usage example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To read a SOFA file call
 
 int filter_length;
 int err;
-struct MYSOFA_EASY *hrtf;
+struct MYSOFA_EASY *hrtf = NULL;
 
 hrtf = mysofa_open("file.sofa", 48000, &filter_length, &err);
 if(hrtf==NULL)


### PR DESCRIPTION
explicitly init mysofa_easy as NULL to avoid segfault in mysofa_close
(see https://stackoverflow.com/questions/35181909/segmentation-fault-on-pointer-null-check)