### PR TITLE
Uniformisation of neighbor lookup creation for all three dimensions (radius, theta, phi)

### DIFF
--- a/src/hrtf/lookup.c
+++ b/src/hrtf/lookup.c
@@ -43,12 +43,12 @@ MYSOFA_EXPORT struct MYSOFA_LOOKUP* mysofa_lookup_init(struct MYSOFA_HRTF *hrtf)
 	for (i = 0; i < hrtf->M; i ++) {
 		memcpy(origin, hrtf->SourcePosition.values + i * hrtf->C, sizeof(float) * hrtf->C);
 		convertCartesianToSpherical(origin, hrtf->C);
-		if (origin[0] < lookup->phi_min){ lookup->phi_min = origin[0]; }
-		if (origin[0] > lookup->phi_max){ lookup->phi_max = origin[0]; }
-		if (origin[1] < lookup->theta_min){ lookup->theta_min = origin[1]; }
-		if (origin[1] > lookup->theta_max){ lookup->theta_max = origin[1]; }
-		if (origin[2] < lookup->radius_min){ lookup->radius_min = origin[2]; }
-		if (origin[2] > lookup->radius_max){ lookup->radius_max = origin[2]; }
+		if (origin[0] < lookup->phi_min){ lookup->phi_min = origin[0]; }
+		if (origin[0] > lookup->phi_max){ lookup->phi_max = origin[0]; }
+		if (origin[1] < lookup->theta_min){ lookup->theta_min = origin[1]; }
+		if (origin[1] > lookup->theta_max){ lookup->theta_max = origin[1]; }
+		if (origin[2] < lookup->radius_min){ lookup->radius_min = origin[2]; }
+		if (origin[2] > lookup->radius_max){ lookup->radius_max = origin[2]; }
 	}
 
 	/*

--- a/src/hrtf/lookup.c
+++ b/src/hrtf/lookup.c
@@ -30,16 +30,25 @@ MYSOFA_EXPORT struct MYSOFA_LOOKUP* mysofa_lookup_init(struct MYSOFA_HRTF *hrtf)
 		return NULL;
 
 	/*
-	 * find smallest and largest radius
-	 */
+	* find smallest and largest phi, theta, and radius (to reduce neighbors table init)
+	*/
+	float* origin;
+	origin = malloc(sizeof(float)*hrtf->C);
+	lookup->phi_min = FLT_MAX;
+	lookup->phi_max = FLT_MIN;
+	lookup->theta_min = FLT_MAX;
+	lookup->theta_max = FLT_MIN;
 	lookup->radius_min = FLT_MAX;
 	lookup->radius_max = FLT_MIN;
 	for (i = 0; i < hrtf->M; i ++) {
-		float r = radius(hrtf->SourcePosition.values + i * hrtf->C);
-		if (r < lookup->radius_min)
-			lookup->radius_min = r;
-		if (r > lookup->radius_max)
-			lookup->radius_max = r;
+		memcpy(origin, hrtf->SourcePosition.values + i * hrtf->C, sizeof(float) * hrtf->C);
+		convertCartesianToSpherical(origin, hrtf->C);
+		if (origin[0] < lookup->phi_min){ lookup->phi_min = origin[0]; }
+		if (origin[0] > lookup->phi_max){ lookup->phi_max = origin[0]; }
+		if (origin[1] < lookup->theta_min){ lookup->theta_min = origin[1]; }
+		if (origin[1] > lookup->theta_max){ lookup->theta_max = origin[1]; }
+		if (origin[2] < lookup->radius_min){ lookup->radius_min = origin[2]; }
+		if (origin[2] > lookup->radius_max){ lookup->radius_max = origin[2]; }
 	}
 
 	/*

--- a/src/hrtf/mysofa.h
+++ b/src/hrtf/mysofa.h
@@ -70,6 +70,8 @@ extern "C" {
 	struct MYSOFA_LOOKUP {
 		void *kdtree;
 		float radius_min, radius_max;
+		float theta_min, theta_max;
+		float phi_min, phi_max;
 	};
 
 	struct MYSOFA_NEIGHBORHOOD {

--- a/src/hrtf/neighbors.c
+++ b/src/hrtf/neighbors.c
@@ -17,8 +17,8 @@ MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA
 	int i, index;
 	float *origin, *test;
 	float radius, radius2;
-	float theta;
-	float phi;
+	float theta, theta2;
+	float phi, phi2;
 
 	struct MYSOFA_NEIGHBORHOOD *neighbor = malloc(
 		sizeof(struct MYSOFA_NEIGHBORHOOD));
@@ -43,7 +43,7 @@ MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA
 
 		phi = 0.5;
 		do {
-			test[0] = origin[0] + phi;
+			phi2 = test[0] = origin[0] + phi;
 			test[1] = origin[1];
 			test[2] = origin[2];
 			convertSphericalToCartesian(test, 3);
@@ -53,11 +53,11 @@ MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA
 				break;
 			}
 			phi += 0.5;
-		} while (phi <= 45);
+		} while (phi2 <= lookup->phi_max);
 
 		phi = -0.5;
 		do {
-			test[0] = origin[0] + phi;
+			phi2 = test[0] = origin[0] + phi;
 			test[1] = origin[1];
 			test[2] = origin[2];
 			convertSphericalToCartesian(test,3);
@@ -67,12 +67,12 @@ MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA
 				break;
 			}
 			phi -= 0.5;
-		} while (phi >= -45);
+		} while (phi2 >= lookup->phi_min);
 
 		theta = 0.5;
 		do {
 			test[0] = origin[0];
-			test[1] = origin[1] + theta;
+			theta2 = test[1] = origin[1] + theta;
 			test[2] = origin[2];
 			convertSphericalToCartesian(test, 3);
 			index = mysofa_lookup(lookup, test);
@@ -81,12 +81,12 @@ MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA
 				break;
 			}
 			theta += 0.5;
-		} while (theta <= 45);
+		} while (theta2 <= lookup->theta_max);
 
 		theta = -0.5;
 		do {
 			test[0] = origin[0];
-			test[1] = origin[1] + theta;
+			theta2 = test[1] = origin[1] + theta;
 			test[2] = origin[2];
 			convertSphericalToCartesian(test, 3);
 			index = mysofa_lookup(lookup, test);
@@ -95,7 +95,7 @@ MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA
 				break;
 			}
 			theta -= 0.5;
-		} while (theta >= -45);
+		} while (theta2 >= lookup->theta_min);
 
 		radius = 0.1;
 		do {

--- a/src/hrtf/neighbors.c
+++ b/src/hrtf/neighbors.c
@@ -19,6 +19,8 @@ MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA
 	float radius, radius2;
 	float theta, theta2;
 	float phi, phi2;
+	float angleStep = 0.5;
+	float radiusStep = 0.01;
 
 	struct MYSOFA_NEIGHBORHOOD *neighbor = malloc(
 		sizeof(struct MYSOFA_NEIGHBORHOOD));
@@ -41,7 +43,7 @@ MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA
 		memcpy(origin, hrtf->SourcePosition.values + i * hrtf->C, sizeof(float) * hrtf->C);
 		convertCartesianToSpherical(origin, hrtf->C);
 
-		phi = 0.5;
+		phi = angleStep;
 		do {
 			phi2 = test[0] = origin[0] + phi;
 			test[1] = origin[1];
@@ -52,10 +54,10 @@ MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA
 				neighbor->index[i * 6 + 0] = index;
 				break;
 			}
-			phi += 0.5;
-		} while (phi2 <= lookup->phi_max + 0.5);
+			phi += angleStep;
+		} while (phi2 <= lookup->phi_max + angleStep);
 
-		phi = -0.5;
+		phi = -angleStep;
 		do {
 			phi2 = test[0] = origin[0] + phi;
 			test[1] = origin[1];
@@ -66,10 +68,10 @@ MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA
 				neighbor->index[i * 6 + 1] = index;
 				break;
 			}
-			phi -= 0.5;
-		} while (phi2 >= lookup->phi_min - 0.5);
+			phi -= angleStep;
+		} while (phi2 >= lookup->phi_min - angleStep);
 
-		theta = 0.5;
+		theta = angleStep;
 		do {
 			test[0] = origin[0];
 			theta2 = test[1] = origin[1] + theta;
@@ -80,10 +82,10 @@ MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA
 				neighbor->index[i * 6 + 2] = index;
 				break;
 			}
-			theta += 0.5;
-		} while (theta2 <= lookup->theta_max + 0.5);
+			theta += angleStep;
+		} while (theta2 <= lookup->theta_max + angleStep);
 
-		theta = -0.5;
+		theta = -angleStep;
 		do {
 			test[0] = origin[0];
 			theta2 = test[1] = origin[1] + theta;
@@ -94,10 +96,10 @@ MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA
 				neighbor->index[i * 6 + 3] = index;
 				break;
 			}
-			theta -= 0.5;
-		} while (theta2 >= lookup->theta_min - 0.5);
+			theta -= angleStep;
+		} while (theta2 >= lookup->theta_min - angleStep);
 
-		radius = 0.01;
+		radius = radiusStep;
 		do {
 			test[0] = origin[0];
 			test[1] = origin[1];
@@ -108,10 +110,10 @@ MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA
 				neighbor->index[i * 6 + 4] = index;
 				break;
 			}
-			radius += 0.01;
-		} while (radius2 <= lookup->radius_max + 0.01);
+			radius += radiusStep;
+		} while (radius2 <= lookup->radius_max + radiusStep);
 
-		radius = -0.01;
+		radius = -radiusStep;
 		do {
 			test[0] = origin[0];
 			test[1] = origin[1];
@@ -122,8 +124,8 @@ MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA
 				neighbor->index[i * 6 + 5] = index;
 				break;
 			}
-			radius -= 0.01;
-		} while (radius2 >= lookup->radius_min - 0.01);
+			radius -= radiusStep;
+		} while (radius2 >= lookup->radius_min - radiusStep);
 	}
 	free(test);
 	free(origin);

--- a/src/hrtf/neighbors.c
+++ b/src/hrtf/neighbors.c
@@ -53,7 +53,7 @@ MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA
 				break;
 			}
 			phi += 0.5;
-		} while (phi2 <= lookup->phi_max);
+		} while (phi2 <= lookup->phi_max + 0.5);
 
 		phi = -0.5;
 		do {
@@ -67,7 +67,7 @@ MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA
 				break;
 			}
 			phi -= 0.5;
-		} while (phi2 >= lookup->phi_min);
+		} while (phi2 >= lookup->phi_min - 0.5);
 
 		theta = 0.5;
 		do {
@@ -81,7 +81,7 @@ MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA
 				break;
 			}
 			theta += 0.5;
-		} while (theta2 <= lookup->theta_max);
+		} while (theta2 <= lookup->theta_max + 0.5);
 
 		theta = -0.5;
 		do {
@@ -95,7 +95,7 @@ MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA
 				break;
 			}
 			theta -= 0.5;
-		} while (theta2 >= lookup->theta_min);
+		} while (theta2 >= lookup->theta_min - 0.5);
 
 		radius = 0.01;
 		do {
@@ -109,7 +109,7 @@ MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA
 				break;
 			}
 			radius += 0.01;
-		} while (radius2 <= lookup->radius_max);
+		} while (radius2 <= lookup->radius_max + 0.01);
 
 		radius = -0.01;
 		do {
@@ -123,7 +123,7 @@ MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA
 				break;
 			}
 			radius -= 0.01;
-		} while (radius2 >= lookup->radius_min);
+		} while (radius2 >= lookup->radius_min - 0.01);
 	}
 	free(test);
 	free(origin);

--- a/src/hrtf/neighbors.c
+++ b/src/hrtf/neighbors.c
@@ -97,7 +97,7 @@ MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA
 			theta -= 0.5;
 		} while (theta2 >= lookup->theta_min);
 
-		radius = 0.1;
+		radius = 0.01;
 		do {
 			test[0] = origin[0];
 			test[1] = origin[1];
@@ -108,21 +108,21 @@ MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA
 				neighbor->index[i * 6 + 4] = index;
 				break;
 			}
-			radius *= 1.5;
+			radius += 0.01;
 		} while (radius2 <= lookup->radius_max);
 
-		radius = 0.1;
+		radius = -0.01;
 		do {
 			test[0] = origin[0];
 			test[1] = origin[1];
-			radius2 = test[2] = origin[2] - radius;
+			radius2 = test[2] = origin[2] + radius;
 			convertSphericalToCartesian(test, 3);
 			index = mysofa_lookup(lookup, test);
 			if (index != i) {
 				neighbor->index[i * 6 + 5] = index;
 				break;
 			}
-			radius *= 1.5;
+			radius -= 0.01;
 		} while (radius2 >= lookup->radius_min);
 	}
 	free(test);


### PR DESCRIPTION
PR aim at reducing lookup creation (upon opening) time for:
*  measurement grids with holes (whole sections where there is no need to iterate to find a neighbor)
* Horizontal measurement grids with only azim (phi) and radius changes (e.g. loading time dropped from 3s to 0.8s by restricting the search to phi_low < .. < phi_high values)

Code-wise, the PR simply removed all differences between radius, theta, and phi search algorithms. It may be that I misjudged the importance of these differences in the first place. You're welcome to ignore this PR then.