### PR TITLE
allow to build project as a cmake subdirectory

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,7 @@ endmacro(use_c99)
 
 use_c99()
 
-configure_file (config.h.in ${CMAKE_SOURCE_DIR}/src/config.h)
+configure_file (config.h.in ${PROJECT_SOURCE_DIR}/src/config.h)
 
 if(NOT MSVC)
   find_library(MATH m)
@@ -21,7 +21,7 @@ else()
   if (NUGET)
     execute_process(COMMAND ${NUGET} install zlib)
   endif()
-  include_directories(${CMAKE_SOURCE_DIR}/windows/third-party/zlib-1.2.11/include/)
+  include_directories(${PROJECT_SOURCE_DIR}/windows/third-party/zlib-1.2.11/include/)
 endif()
 
 # include(FindZLIB)
@@ -39,7 +39,7 @@ else()
     else()
          execute_process(COMMAND ${NUGET} install zlib)
     endif()
-    include_directories(${CMAKE_SOURCE_DIR}/windows/third-party/zlib-1.2.11/include/)
+    include_directories(${PROJECT_SOURCE_DIR}/windows/third-party/zlib-1.2.11/include/)
 endif()
 
 
@@ -59,12 +59,12 @@ if(BUILD_SHARED_LIBS)
   set_property(TARGET mysofa-shared PROPERTY VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
   set_property(TARGET mysofa-shared PROPERTY SOVERSION ${CPACK_PACKAGE_VERSION_MAJOR} )
   set_property(TARGET mysofa-shared PROPERTY C_VISIBILITY_PRESET hidden)
-  GENERATE_EXPORT_HEADER(mysofa-shared BASE_NAME mysofa EXPORT_FILE_NAME ${CMAKE_SOURCE_DIR}/src/hrtf/mysofa_export.h)
+  GENERATE_EXPORT_HEADER(mysofa-shared BASE_NAME mysofa EXPORT_FILE_NAME ${PROJECT_SOURCE_DIR}/src/hrtf/mysofa_export.h)
   install(TARGETS mysofa-shared 
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 else()
-  GENERATE_EXPORT_HEADER(mysofa-static BASE_NAME mysofa EXPORT_FILE_NAME ${CMAKE_SOURCE_DIR}/src/hrtf/mysofa_export.h)
+  GENERATE_EXPORT_HEADER(mysofa-static BASE_NAME mysofa EXPORT_FILE_NAME ${PROJECT_SOURCE_DIR}/src/hrtf/mysofa_export.h)
 endif()
 
 install(FILES hrtf/mysofa.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
PROJECT_SOURCE_DIR points to the source dir of the most recent project() call, while CMAKE_SOURCE_DIR points to the top-level project.