### PR TITLE
Optimize Neighbor search for exotic scenario 

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ This call will normalize your hrtf data upon opening. For non-normalized data, r
 hrtf = mysofa_open_no_norm("file.sofa", 48000, &filter_length, &err);
 ```
 
+Or for a complete control over neighbors search algorithm parameters:
+
+```
+bool norm = true; // bool, apply normalization upon import
+float neighbor_angle_step = 5; // in degree, neighbor search angle step (common to azimuth and elevation)
+float neighbor_radius_step = 0.01; // in meters, neighbor search radius step
+hrtf = mysofa_open_advanced("file.sofa", 48000, &filter_length, &err, norm, neighbor_angle_step, neighbor_radius_step);
+```
+
+(The greater the neighbor_*_step, the faster the neighbors search. The algorithm will end up skipping true nearest neighbors if these values are set too high. To be define based on the will-be-imported sofa files grid step. Default mysofa_open method is usually fast enough for classical hrtf grids not to bother with the advanced one.)
+
 To free the HRTF structure, call:
 ```
 mysofa_close(hrtf);

--- a/src/hrtf/easy.c
+++ b/src/hrtf/easy.c
@@ -16,7 +16,7 @@
  *
  */
 
-static struct MYSOFA_EASY* mysofa_open_default(const char *filename, float samplerate, int *filterlength, int *err, bool applyNorm)
+static struct MYSOFA_EASY* mysofa_open_default(const char *filename, float samplerate, int *filterlength, int *err, bool applyNorm, float neighbor_angle_step, float neighbor_radius_step)
 {
 	struct MYSOFA_EASY *easy = malloc(sizeof(struct MYSOFA_EASY));
 	if(!easy) {
@@ -62,8 +62,8 @@ static struct MYSOFA_EASY* mysofa_open_default(const char *filename, float sampl
 		return NULL;
 	}
 
-	easy->neighborhood = mysofa_neighborhood_init(easy->hrtf,
-						      easy->lookup);
+	easy->neighborhood = mysofa_neighborhood_init_withstepdefine(easy->hrtf,
+						      easy->lookup,neighbor_angle_step,neighbor_radius_step);
 
 	*filterlength = easy->hrtf->N;
 
@@ -72,12 +72,17 @@ static struct MYSOFA_EASY* mysofa_open_default(const char *filename, float sampl
 
 MYSOFA_EXPORT struct MYSOFA_EASY* mysofa_open(const char *filename, float samplerate, int *filterlength, int *err)
 {
-	return mysofa_open_default(filename,samplerate,filterlength,err,true);
+	return mysofa_open_default(filename,samplerate,filterlength,err,true,MYSOFA_DEFAULT_NEIGH_STEP_ANGLE,MYSOFA_DEFAULT_NEIGH_STEP_RADIUS);
 }
 
 MYSOFA_EXPORT struct MYSOFA_EASY* mysofa_open_no_norm(const char *filename, float samplerate, int *filterlength, int *err)
 {
-	return mysofa_open_default(filename,samplerate,filterlength,err,false);
+	return mysofa_open_default(filename,samplerate,filterlength,err,false,MYSOFA_DEFAULT_NEIGH_STEP_ANGLE,MYSOFA_DEFAULT_NEIGH_STEP_RADIUS);
+}
+
+MYSOFA_EXPORT struct MYSOFA_EASY* mysofa_open_advanced(const char *filename, float samplerate, int *filterlength, int *err, bool norm, float neighbor_angle_step, float neighbor_radius_step)
+{
+	return mysofa_open_default(filename,samplerate,filterlength,err,norm,neighbor_angle_step,neighbor_radius_step);
 }
 
 MYSOFA_EXPORT struct MYSOFA_EASY* mysofa_open_cached(const char *filename, float samplerate, int *filterlength, int *err)

--- a/src/hrtf/mysofa.h
+++ b/src/hrtf/mysofa.h
@@ -6,11 +6,14 @@
 
 #ifndef MYSOFA_H_INCLUDED
 #define MYSOFA_H_INCLUDED
+#define MYSOFA_DEFAULT_NEIGH_STEP_ANGLE 0.5
+#define MYSOFA_DEFAULT_NEIGH_STEP_RADIUS 0.01
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #include <stdint.h>
+#include <stdbool.h>
 
 /** attributes */
 	struct MYSOFA_ATTRIBUTE {
@@ -102,6 +105,8 @@ extern "C" {
 
 	struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA_HRTF *hrtf,
 							     struct MYSOFA_LOOKUP *lookup);
+	struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init_withstepdefine(struct MYSOFA_HRTF *hrtf,
+							     struct MYSOFA_LOOKUP *lookup,float neighbor_angle_step,float neighbor_radius_step);
 	int* mysofa_neighborhood(struct MYSOFA_NEIGHBORHOOD *neighborhood, int pos);
 	void mysofa_neighborhood_free(struct MYSOFA_NEIGHBORHOOD *neighborhood);
 
@@ -128,6 +133,7 @@ extern "C" {
 
 	struct MYSOFA_EASY* mysofa_open(const char *filename, float samplerate, int *filterlength, int *err);
 	struct MYSOFA_EASY* mysofa_open_no_norm(const char *filename, float samplerate, int *filterlength, int *err);
+	struct MYSOFA_EASY* mysofa_open_advanced(const char *filename, float samplerate, int *filterlength, int *err, bool norm, float neighbor_angle_step, float neighbor_radius_step);
 	struct MYSOFA_EASY* mysofa_open_cached(const char *filename, float samplerate, int *filterlength, int *err);
 	void mysofa_getfilter_short(struct MYSOFA_EASY* easy, float x, float y, float z,
 				    short *IRleft, short *IRright,

--- a/src/hrtf/mysofa.h
+++ b/src/hrtf/mysofa.h
@@ -6,14 +6,15 @@
 
 #ifndef MYSOFA_H_INCLUDED
 #define MYSOFA_H_INCLUDED
-#define MYSOFA_DEFAULT_NEIGH_STEP_ANGLE 0.5
-#define MYSOFA_DEFAULT_NEIGH_STEP_RADIUS 0.01
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #include <stdint.h>
 #include <stdbool.h>
+
+#define MYSOFA_DEFAULT_NEIGH_STEP_ANGLE 0.5
+#define MYSOFA_DEFAULT_NEIGH_STEP_RADIUS 0.01
 
 /** attributes */
 	struct MYSOFA_ATTRIBUTE {

--- a/src/hrtf/neighbors.c
+++ b/src/hrtf/neighbors.c
@@ -8,19 +8,25 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <float.h>
 #include "mysofa_export.h"
 #include "mysofa.h"
 #include "tools.h"
 
 MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init(struct MYSOFA_HRTF *hrtf,
 								   struct MYSOFA_LOOKUP *lookup) {
+	return mysofa_neighborhood_init_withstepdefine(hrtf,lookup,MYSOFA_DEFAULT_NEIGH_STEP_ANGLE,MYSOFA_DEFAULT_NEIGH_STEP_RADIUS);
+}
+
+MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init_withstepdefine(struct MYSOFA_HRTF *hrtf,
+								   struct MYSOFA_LOOKUP *lookup,
+								   float angleStep,
+								   float radiusStep) {
 	int i, index;
 	float *origin, *test;
 	float radius, radius2;
 	float theta, theta2;
 	float phi, phi2;
-	float angleStep = 0.5;
-	float radiusStep = 0.01;
 
 	struct MYSOFA_NEIGHBORHOOD *neighbor = malloc(
 		sizeof(struct MYSOFA_NEIGHBORHOOD));

--- a/src/hrtf/neighbors.c
+++ b/src/hrtf/neighbors.c
@@ -49,89 +49,95 @@ MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init_withstepdefin
 		memcpy(origin, hrtf->SourcePosition.values + i * hrtf->C, sizeof(float) * hrtf->C);
 		convertCartesianToSpherical(origin, hrtf->C);
 
-		phi = angleStep;
-		do {
-			phi2 = test[0] = origin[0] + phi;
-			test[1] = origin[1];
-			test[2] = origin[2];
-			convertSphericalToCartesian(test, 3);
-			index = mysofa_lookup(lookup, test);
-			if (index != i) {
-				neighbor->index[i * 6 + 0] = index;
-				break;
-			}
-			phi += angleStep;
-		} while (phi2 <= lookup->phi_max + angleStep);
+		if( (lookup->phi_max - lookup->phi_min) > FLT_MIN ){
+			phi = angleStep;
+			do {
+				phi2 = test[0] = origin[0] + phi;
+				test[1] = origin[1];
+				test[2] = origin[2];
+				convertSphericalToCartesian(test, 3);
+				index = mysofa_lookup(lookup, test);
+				if (index != i) {
+					neighbor->index[i * 6 + 0] = index;
+					break;
+				}
+				phi += angleStep;
+			} while (phi2 <= lookup->phi_max + angleStep);
 
-		phi = -angleStep;
-		do {
-			phi2 = test[0] = origin[0] + phi;
-			test[1] = origin[1];
-			test[2] = origin[2];
-			convertSphericalToCartesian(test,3);
-			index = mysofa_lookup(lookup, test);
-			if (index != i) {
-				neighbor->index[i * 6 + 1] = index;
-				break;
-			}
-			phi -= angleStep;
-		} while (phi2 >= lookup->phi_min - angleStep);
+			phi = -angleStep;
+			do {
+				phi2 = test[0] = origin[0] + phi;
+				test[1] = origin[1];
+				test[2] = origin[2];
+				convertSphericalToCartesian(test,3);
+				index = mysofa_lookup(lookup, test);
+				if (index != i) {
+					neighbor->index[i * 6 + 1] = index;
+					break;
+				}
+				phi -= angleStep;
+			} while (phi2 >= lookup->phi_min - angleStep);
+		}
 
-		theta = angleStep;
-		do {
-			test[0] = origin[0];
-			theta2 = test[1] = origin[1] + theta;
-			test[2] = origin[2];
-			convertSphericalToCartesian(test, 3);
-			index = mysofa_lookup(lookup, test);
-			if (index != i) {
-				neighbor->index[i * 6 + 2] = index;
-				break;
-			}
-			theta += angleStep;
-		} while (theta2 <= lookup->theta_max + angleStep);
+		if( (lookup->theta_max - lookup->theta_min) > FLT_MIN ){
+			theta = angleStep;
+			do {
+				test[0] = origin[0];
+				theta2 = test[1] = origin[1] + theta;
+				test[2] = origin[2];
+				convertSphericalToCartesian(test, 3);
+				index = mysofa_lookup(lookup, test);
+				if (index != i) {
+					neighbor->index[i * 6 + 2] = index;
+					break;
+				}
+				theta += angleStep;
+			} while (theta2 <= lookup->theta_max + angleStep);
 
-		theta = -angleStep;
-		do {
-			test[0] = origin[0];
-			theta2 = test[1] = origin[1] + theta;
-			test[2] = origin[2];
-			convertSphericalToCartesian(test, 3);
-			index = mysofa_lookup(lookup, test);
-			if (index != i) {
-				neighbor->index[i * 6 + 3] = index;
-				break;
-			}
-			theta -= angleStep;
-		} while (theta2 >= lookup->theta_min - angleStep);
+			theta = -angleStep;
+			do {
+				test[0] = origin[0];
+				theta2 = test[1] = origin[1] + theta;
+				test[2] = origin[2];
+				convertSphericalToCartesian(test, 3);
+				index = mysofa_lookup(lookup, test);
+				if (index != i) {
+					neighbor->index[i * 6 + 3] = index;
+					break;
+				}
+				theta -= angleStep;
+			} while (theta2 >= lookup->theta_min - angleStep);
+		}
 
-		radius = radiusStep;
-		do {
-			test[0] = origin[0];
-			test[1] = origin[1];
-			radius2 = test[2] = origin[2] + radius;
-			convertSphericalToCartesian(test, 3);
-			index = mysofa_lookup(lookup, test);
-			if (index != i) {
-				neighbor->index[i * 6 + 4] = index;
-				break;
-			}
-			radius += radiusStep;
-		} while (radius2 <= lookup->radius_max + radiusStep);
+		if( (lookup->radius_max - lookup->radius_min) > FLT_MIN ){
+			radius = radiusStep;
+			do {
+				test[0] = origin[0];
+				test[1] = origin[1];
+				radius2 = test[2] = origin[2] + radius;
+				convertSphericalToCartesian(test, 3);
+				index = mysofa_lookup(lookup, test);
+				if (index != i) {
+					neighbor->index[i * 6 + 4] = index;
+					break;
+				}
+				radius += radiusStep;
+			} while (radius2 <= lookup->radius_max + radiusStep);
 
-		radius = -radiusStep;
-		do {
-			test[0] = origin[0];
-			test[1] = origin[1];
-			radius2 = test[2] = origin[2] + radius;
-			convertSphericalToCartesian(test, 3);
-			index = mysofa_lookup(lookup, test);
-			if (index != i) {
-				neighbor->index[i * 6 + 5] = index;
-				break;
-			}
-			radius -= radiusStep;
-		} while (radius2 >= lookup->radius_min - radiusStep);
+			radius = -radiusStep;
+			do {
+				test[0] = origin[0];
+				test[1] = origin[1];
+				radius2 = test[2] = origin[2] + radius;
+				convertSphericalToCartesian(test, 3);
+				index = mysofa_lookup(lookup, test);
+				if (index != i) {
+					neighbor->index[i * 6 + 5] = index;
+					break;
+				}
+				radius -= radiusStep;
+			} while (radius2 >= lookup->radius_min - radiusStep);
+		}
 	}
 	free(test);
 	free(origin);


### PR DESCRIPTION
Added both a manual definition of neighbors search angle/radius step to the API (no breaking changes), and an auto-skip of said search if min/max values of search grid are the same (zeroed-out dimension). 

The revised version allows to decrease loading time for exotic SOFA files (when users know what they are doing), e.g. from 1200ms to 200ms for a grid with no elevation and lots of azim and dist points.

Do let me know what you think.