### PR TITLE
Remove dead code

### DIFF
--- a/src/hrtf/check.c
+++ b/src/hrtf/check.c
@@ -15,9 +15,9 @@ static int compareValues(struct MYSOFA_ARRAY *array, float *compare,
 	return 1;
 }
 
-static float array000[] = { 0, 0, 0 };
-static float array001[] = { 0, 0, 1 };
-static float array100[] = { 1, 0, 0 };
+static const float array000[] = { 0, 0, 0 };
+static const float array001[] = { 0, 0, 1 };
+static const float array100[] = { 1, 0, 0 };
 
 MYSOFA_EXPORT int mysofa_check(struct MYSOFA_HRTF *hrtf) {
 

--- a/src/hrtf/kdtree.h
+++ b/src/hrtf/kdtree.h
@@ -32,7 +32,6 @@ extern "C" {
 #endif
 
 struct kdtree;
-struct kdres;
 
 /* create a kd-tree for "k"-dimensional data */
 struct kdtree *kd_create(int k);
@@ -40,90 +39,11 @@ struct kdtree *kd_create(int k);
 /* free the struct kdtree */
 void kd_free(struct kdtree *tree);
 
-/* remove all the elements from the tree */
-void kd_clear(struct kdtree *tree);
-
-/* if called with non-null 2nd argument, the function provided
- * will be called on data pointers (see kd_insert) when nodes
- * are to be removed from the tree.
- */
-void kd_data_destructor(struct kdtree *tree, void (*destr)(void*));
-
 /* insert a node, specifying its position, and optional data */
 int kd_insert(struct kdtree *tree, const float *pos, void *data);
-int kd_insertf(struct kdtree *tree, const float *pos, void *data);
-int kd_insert3(struct kdtree *tree, float x, float y, float z, void *data);
-int kd_insert3f(struct kdtree *tree, float x, float y, float z, void *data);
 
-/* Find the nearest node from a given point.
- *
- * This function returns a pointer to a result set with at most one element.
- */
-struct kdres *kd_nearest(struct kdtree *tree, const float *pos);
-int kd_nearest_noalloc(struct kdtree *tree, const float *pos, void **res);
-struct kdres *kd_nearestf(struct kdtree *tree, const float *pos);
-struct kdres *kd_nearest3(struct kdtree *tree, float x, float y, float z);
-struct kdres *kd_nearest3f(struct kdtree *tree, float x, float y, float z);
-
-/* Find the N nearest nodes from a given point.
- *
- * This function returns a pointer to a result set, with at most N elements,
- * which can be manipulated with the kd_res_* functions.
- * The returned pointer can be null as an indication of an error. Otherwise
- * a valid result set is always returned which may contain 0 or more elements.
- * The result set must be deallocated with kd_res_free after use.
- */
-/*
- struct kdres *kd_nearest_n(struct kdtree *tree, const float *pos, int num);
- struct kdres *kd_nearest_nf(struct kdtree *tree, const float *pos, int num);
- struct kdres *kd_nearest_n3(struct kdtree *tree, float x, float y, float z);
- struct kdres *kd_nearest_n3f(struct kdtree *tree, float x, float y, float z);
- */
-
-/* Find any nearest nodes from a given point within a range.
- *
- * This function returns a pointer to a result set, which can be manipulated
- * by the kd_res_* functions.
- * The returned pointer can be null as an indication of an error. Otherwise
- * a valid result set is always returned which may contain 0 or more elements.
- * The result set must be deallocated with kd_res_free after use.
- */
-struct kdres *kd_nearest_range(struct kdtree *tree, const float *pos,
-		float range);
-struct kdres *kd_nearest_rangef(struct kdtree *tree, const float *pos,
-		float range);
-struct kdres *kd_nearest_range3(struct kdtree *tree, float x, float y, float z,
-		float range);
-struct kdres *kd_nearest_range3f(struct kdtree *tree, float x, float y, float z,
-		float range);
-
-/* frees a result set returned by kd_nearest_range() */
-void kd_res_free(struct kdres *set);
-
-/* returns the size of the result set (in elements) */
-int kd_res_size(struct kdres *set);
-
-/* rewinds the result set iterator */
-void kd_res_rewind(struct kdres *set);
-
-/* returns non-zero if the set iterator reached the end after the last element */
-int kd_res_end(struct kdres *set);
-
-/* advances the result set iterator, returns non-zero on success, zero if
- * there are no more elements in the result set.
- */
-int kd_res_next(struct kdres *set);
-
-/* returns the data pointer (can be null) of the current result set item
- * and optionally sets its position to the pointers(s) if not null.
- */
-void *kd_res_item(struct kdres *set, float *pos);
-void *kd_res_itemf(struct kdres *set, float *pos);
-void *kd_res_item3(struct kdres *set, float *x, float *y, float *z);
-void *kd_res_item3f(struct kdres *set, float *x, float *y, float *z);
-
-/* equivalent to kd_res_item(set, 0) */
-void *kd_res_item_data(struct kdres *set);
+/* Find the nearest node from a given point */
+int kd_nearest(struct kdtree *tree, const float *pos, void **res);
 
 #ifdef __cplusplus
 }

--- a/src/hrtf/lookup.c
+++ b/src/hrtf/lookup.c
@@ -108,7 +108,7 @@ MYSOFA_EXPORT int mysofa_lookup(struct MYSOFA_LOOKUP *lookup, float *coordinate)
 		coordinate[2] *= r;
 	}
 
-	success = kd_nearest_noalloc((struct kdtree *) lookup->kdtree, coordinate, &res);
+	success = kd_nearest((struct kdtree *) lookup->kdtree, coordinate, &res);
 	if (success != 0) {
 		return MYSOFA_INTERNAL_ERROR;
 	}


### PR DESCRIPTION
My goal is to completely avoid allocations in `mysofa_lookup()` at some point.

As a first step, to get a better overview, I started removing dead code, and it turns out there's a lot of it.