### PR TITLE
Limit KD-Tree to exactly 3 dimensions

### DIFF
--- a/src/hrtf/check.c
+++ b/src/hrtf/check.c
@@ -4,7 +4,7 @@
 #include "mysofa.h"
 #include "tools.h"
 
-static int compareValues(struct MYSOFA_ARRAY *array, float *compare,
+static int compareValues(struct MYSOFA_ARRAY *array, const float *compare,
 		int elements) {
 	int i;
 	if (array->values == NULL || array->elements != elements)

--- a/src/hrtf/kdtree.h
+++ b/src/hrtf/kdtree.h
@@ -33,8 +33,8 @@ extern "C" {
 
 struct kdtree;
 
-/* create a kd-tree for "k"-dimensional data */
-struct kdtree *kd_create(int k);
+/* create a kd-tree for 3-dimensional data */
+struct kdtree *kd_create();
 
 /* free the struct kdtree */
 void kd_free(struct kdtree *tree);

--- a/src/hrtf/lookup.c
+++ b/src/hrtf/lookup.c
@@ -68,7 +68,7 @@ MYSOFA_EXPORT struct MYSOFA_LOOKUP* mysofa_lookup_init(struct MYSOFA_HRTF *hrtf)
 	/*
 	 * Allocate kd tree
 	 */
-	lookup->kdtree = kd_create(3);
+	lookup->kdtree = kd_create();
 	if (!lookup->kdtree) {
 		free(lookup);
 		return NULL;


### PR DESCRIPTION
This should get rid of all dynamic allocations in `mysofa_lookup()`.