### PR TITLE
Fix coverage build with CMake 3.13 and later

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,7 +89,7 @@ if(UNIX
   target_compile_options(mysofa-static PUBLIC -g -O0 -Wall -fprofile-arcs
                                               -ftest-coverage)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
-    target_link_options(mysofa-static INTERFACE gcov --coverage)
+    target_link_options(mysofa-static INTERFACE --coverage)
   else()
     target_link_libraries(mysofa-static LINK_PUBLIC gcov --coverage)
   endif()
@@ -118,7 +118,7 @@ if(BUILD_SHARED_LIBS)
     target_compile_options(mysofa-shared PUBLIC -g -O0 -Wall -fprofile-arcs
                                                 -ftest-coverage)
     if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
-      target_link_options(mysofa-shared INTERFACE gcov --coverage)
+      target_link_options(mysofa-shared INTERFACE --coverage)
     else()
       target_link_libraries(mysofa-shared LINK_PUBLIC gcov --coverage)
     endif()


### PR DESCRIPTION
Fixes #109

Build fails with CMake 3.13 and later. This fixes the issue.

Tested in Arch Linux x86_64 with CMake 3.16.4 and gcc/gcov 9.2.1.