### PR TITLE
Fix undefined references to gcov symbols in the library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,7 +89,7 @@ if(UNIX
   target_compile_options(mysofa-static PUBLIC -g -O0 -Wall -fprofile-arcs
                                               -ftest-coverage)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
-    target_link_options(mysofa-static INTERFACE --coverage)
+    target_link_options(mysofa-static PUBLIC --coverage)
   else()
     target_link_libraries(mysofa-static LINK_PUBLIC gcov --coverage)
   endif()
@@ -118,7 +118,7 @@ if(BUILD_SHARED_LIBS)
     target_compile_options(mysofa-shared PUBLIC -g -O0 -Wall -fprofile-arcs
                                                 -ftest-coverage)
     if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
-      target_link_options(mysofa-shared INTERFACE --coverage)
+      target_link_options(mysofa-shared PUBLIC --coverage)
     else()
       target_link_libraries(mysofa-shared LINK_PUBLIC gcov --coverage)
     endif()


### PR DESCRIPTION
The linking should be of the `PUBLIC` type, otherwise we will get
errors like 'undefined reference to __gcov_merge_add' when using
the library with other applications.