### PR TITLE
tests/compare.sh cleanup

### DIFF
--- a/tests/compare.sh
+++ b/tests/compare.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 
-NODEJS=`which node || which nodejs || which false`
-../build/src/mysofa2json -s "$1".sofa >tmp1.json 2>tmp1.txt 
+SCRIPTDIR=${0%/*}
+NODEJS=$(which node nodejs false | head -1)
+
+${MYSOFA2JSON:-${SCRIPTDIR}/../build/src/mysofa2json} -s "$1".sofa >tmp1.json 2>tmp1.txt
 
 ret=$?
 if [ "$ret" != 0 ]; then 
@@ -10,9 +12,9 @@ if [ "$ret" != 0 ]; then
     exit $ret
 fi
 
-cp -f ../tests/json-diff.js . 2>/dev/null || true
+cp -f "${SCRIPTDIR}/json-diff.js" . 2>/dev/null || true
 bunzip2 -c -k "$1".json.bz2 >./tmp2.json
-$NODEJS ./json-diff.js ./tmp1.json ./tmp2.json
+"${NODEJS}" ./json-diff.js ./tmp1.json ./tmp2.json
 ret=$?
 if [ "$ret" != 0 ]; then 
     echo Diff $ret


### PR DESCRIPTION
- properly quote paths (think spaces!)
- allow to run tests in another directory
- allow to override the "mysofa2json" binary
   - when *not* building in./build/
   - when testing a system-wide installed mysofa2json
- use `$(...)` syntax rather than `` `...` ``