### PR TITLE
pkgsrc fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,19 +48,19 @@ if(BUILD_TESTS)
   enable_testing()
 
   add_test(D1_48K_24bit_0.3s_FIR_SOFA src/mysofa2json
-           ../tests/D1_48K_24bit_0.3s_FIR_SOFA.sofa)
-  add_test(H20_44K_16bit_256tap_FIR_SOFA ../tests/compareIgnoreNew.sh
-           ../tests/H20_44K_16bit_256tap_FIR_SOFA)
-  add_test(MIT_KEMAR_large_pinna ../tests/compare.sh
-           ../tests/MIT_KEMAR_large_pinna)
-  add_test(MIT_KEMAR_normal_pinna ../tests/compareIgnoreNew.sh
-           ../tests/MIT_KEMAR_normal_pinna)
-  add_test(MIT_KEMAR_normal_pinna.old ../tests/compare.sh
-           ../tests/MIT_KEMAR_normal_pinna.old)
-  add_test(dtf_nh2 ../tests/compareIgnoreNew.sh
-           ../tests/dtf_nh2)
-  add_test(hrtf_c_nh898 ../tests/compareIgnoreNew.sh
-           ../tests/hrtf_c_nh898)
+           ${PROJECT_SOURCE_DIR}/tests/D1_48K_24bit_0.3s_FIR_SOFA.sofa)
+  add_test(H20_44K_16bit_256tap_FIR_SOFA ${PROJECT_SOURCE_DIR}/tests/compareIgnoreNew.sh
+           ${PROJECT_SOURCE_DIR}/tests/H20_44K_16bit_256tap_FIR_SOFA)
+  add_test(MIT_KEMAR_large_pinna ${PROJECT_SOURCE_DIR}/tests/compare.sh
+           ${PROJECT_SOURCE_DIR}/tests/MIT_KEMAR_large_pinna)
+  add_test(MIT_KEMAR_normal_pinna ${PROJECT_SOURCE_DIR}/tests/compareIgnoreNew.sh
+           ${PROJECT_SOURCE_DIR}/tests/MIT_KEMAR_normal_pinna)
+  add_test(MIT_KEMAR_normal_pinna.old ${PROJECT_SOURCE_DIR}/tests/compare.sh
+           ${PROJECT_SOURCE_DIR}/tests/MIT_KEMAR_normal_pinna.old)
+  add_test(dtf_nh2 ${PROJECT_SOURCE_DIR}/tests/compareIgnoreNew.sh
+           ${PROJECT_SOURCE_DIR}/tests/dtf_nh2)
+  add_test(hrtf_c_nh898 ${PROJECT_SOURCE_DIR}/tests/compareIgnoreNew.sh
+           ${PROJECT_SOURCE_DIR}/tests/hrtf_c_nh898)
   foreach(
     ISSUE
     72
@@ -72,26 +72,26 @@ if(BUILD_TESTS)
     83
     84)
     # issues with osx    96)
-    add_test(fail-issue-${ISSUE} ../tests/notcrashed.sh
-             ../tests/fail-issue-${ISSUE})
+    add_test(fail-issue-${ISSUE} ${PROJECT_SOURCE_DIR}/tests/notcrashed.sh
+             ${PROJECT_SOURCE_DIR}/tests/fail-issue-${ISSUE})
   endforeach(ISSUE)
-  add_test(CIPIC_subject_003_hrir_final ../tests/compare.sh
-           ../tests/CIPIC_subject_003_hrir_final)
-  add_test(FHK_HRIR_L2354 ../tests/compare.sh ../tests/FHK_HRIR_L2354)
-  add_test(LISTEN_1002_IRC_1002_C_HRIR ../tests/compare.sh
-           ../tests/LISTEN_1002_IRC_1002_C_HRIR)
-  add_test(Pulse ../tests/compare.sh ../tests/Pulse)
-  add_test(Tester ../tests/compare.sh ../tests/tester)
-  add_test(TU-Berlin_QU_KEMAR_anechoic_radius_0.5_1_2_3_m ../tests/compare.sh
-           ../tests/TU-Berlin_QU_KEMAR_anechoic_radius_0.5_1_2_3_m)
-  add_test(TU-Berlin_QU_KEMAR_anechoic_radius_0.5m ../tests/compare.sh
-           ../tests/TU-Berlin_QU_KEMAR_anechoic_radius_0.5m)
-  add_test(example_dummy_sofa48 ../tests/compare.sh
-           ../tests/example_dummy_sofa48)
-  add_test(TestSOFA48_netcdf472 ../tests/compare.sh
-           ../tests/TestSOFA48_netcdf472)
-  add_test(example_dummy_sofa48_with_user_defined_variable ../tests/compare.sh
-           ../tests/example_dummy_sofa48_with_user_defined_variable)
+  add_test(CIPIC_subject_003_hrir_final ${PROJECT_SOURCE_DIR}/tests/compare.sh
+           ${PROJECT_SOURCE_DIR}/tests/CIPIC_subject_003_hrir_final)
+  add_test(FHK_HRIR_L2354 ${PROJECT_SOURCE_DIR}/tests/compare.sh ${PROJECT_SOURCE_DIR}/tests/FHK_HRIR_L2354)
+  add_test(LISTEN_1002_IRC_1002_C_HRIR ${PROJECT_SOURCE_DIR}/tests/compare.sh
+           ${PROJECT_SOURCE_DIR}/tests/LISTEN_1002_IRC_1002_C_HRIR)
+  add_test(Pulse ${PROJECT_SOURCE_DIR}/tests/compare.sh ${PROJECT_SOURCE_DIR}/tests/Pulse)
+  add_test(Tester ${PROJECT_SOURCE_DIR}/tests/compare.sh ${PROJECT_SOURCE_DIR}/tests/tester)
+  add_test(TU-Berlin_QU_KEMAR_anechoic_radius_0.5_1_2_3_m ${PROJECT_SOURCE_DIR}/tests/compare.sh
+           ${PROJECT_SOURCE_DIR}/tests/TU-Berlin_QU_KEMAR_anechoic_radius_0.5_1_2_3_m)
+  add_test(TU-Berlin_QU_KEMAR_anechoic_radius_0.5m ${PROJECT_SOURCE_DIR}/tests/compare.sh
+           ${PROJECT_SOURCE_DIR}/tests/TU-Berlin_QU_KEMAR_anechoic_radius_0.5m)
+  add_test(example_dummy_sofa48 ${PROJECT_SOURCE_DIR}/tests/compare.sh
+           ${PROJECT_SOURCE_DIR}/tests/example_dummy_sofa48)
+  add_test(TestSOFA48_netcdf472 ${PROJECT_SOURCE_DIR}/tests/compare.sh
+           ${PROJECT_SOURCE_DIR}/tests/TestSOFA48_netcdf472)
+  add_test(example_dummy_sofa48_with_user_defined_variable ${PROJECT_SOURCE_DIR}/tests/compare.sh
+           ${PROJECT_SOURCE_DIR}/tests/example_dummy_sofa48_with_user_defined_variable)
 endif(BUILD_TESTS)
 
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
-project(libmysofa)
+project(libmysofa C)
 
 include(CheckCCompilerFlag)
 include(GenerateExportHeader)


### PR DESCRIPTION
Hi!
Here are two patches from pkgsrc.
The relative paths are inconvenient if you are not using a "build" subdirectory as your build directory but some other path.
Thanks.