### PR TITLE
Build proper release binaries by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 before_script:
   - mkdir -p build
   - cd build
-  - cmake -DCMAKE_BUILD_TYPE=Debug ..
+  - cmake -DCMAKE_BUILD_TYPE=Debug -DCODE_COVERAGE=ON ..
 
 script:
   - pwd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(GNUInstallDirs)
 option(BUILD_TESTS "Build test programs" ON)
 option(BUILD_SHARED_LIBS "Build shared library" ON)
 option(BUILD_STATIC_LIBS "Build static library" ON)
-option(CODE_COVERAGE "Enable coverage reporting" ON)
+option(CODE_COVERAGE "Enable coverage reporting" OFF)
 
 set(CPACK_PACKAGE_DESCRIPTION "SOFA file reader for better HRTFs")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY


### PR DESCRIPTION
Build proper release binaries by default
Because `-fprofile-arcs` introduces non-determinism via
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96970
and release binaries should not be instrumented like this anyway.

This change makes life easier for distribution packagers.

This PR was done while working on reproducible builds for openSUSE.