### PR TITLE
Enable POSITION_INDEPENDENT_CODE just when BUILD_SHARED_LIBS is on

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,7 +81,7 @@ target_link_libraries(mysofa-static LINK_PRIVATE ${MATH} ${ZLIB_LIBRARIES})
 set_target_properties(
   mysofa-static
   PROPERTIES OUTPUT_NAME mysofa CLEAN_DIRECT_OUTPUT 1 POSITION_INDEPENDENT_CODE
-                                                      ON)
+                                                      $BUILD_SHARED_LIBS)
 install(TARGETS mysofa-static ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
   if(UNIX


### PR DESCRIPTION
Otherwise, it could suffer compilation issues when cross-compiling (I'm compiling library for `PSP`)

```
make 
Scanning dependencies of target mysofa-static
[  4%] Building C object src/CMakeFiles/mysofa-static.dir/hrtf/reader.c.obj
cc1: error: cannot generate position-independent code for ‘-mabi=eabi’
make[2]: *** [src/CMakeFiles/mysofa-static.dir/hrtf/reader.c.obj] Error 1
make[1]: *** [src/CMakeFiles/mysofa-static.dir/all] Error 2
make: *** [all] Error 2
```

Thanks