### PR TITLE
Load HRTF from memory instead of file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ build/
 src/hrtf/mysofa_export.h
 src/config.h
 
+.vscode/settings.json

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -149,7 +149,8 @@ if(BUILD_TESTS)
   add_executable(
     external
     tests/external.c
-    tests/check.c
+    tests/check.c 
+    tests/check_data.c 
     tests/lookup.c
     tests/neighbors.c
     tests/interpolate.c

--- a/src/hrtf/mysofa.h
+++ b/src/hrtf/mysofa.h
@@ -180,6 +180,14 @@ struct MYSOFA_EASY *mysofa_open_advanced(const char *filename, float samplerate,
                                          int *filterlength, int *err, bool norm,
                                          float neighbor_angle_step,
                                          float neighbor_radius_step);
+struct MYSOFA_EASY *mysofa_open_data(const char *data, int size, float samplerate,
+                                     int *filterlength, int *err);
+struct MYSOFA_EASY *mysofa_open_data_no_norm(const char *data, int size, float samplerate,
+                                             int *filterlength, int *err);
+struct MYSOFA_EASY *mysofa_open_data_advanced(const char *data, int size, float samplerate,
+                                              int *filterlength, int *err, bool norm,
+                                              float neighbor_angle_step,
+                                              float neighbor_radius_step);
 struct MYSOFA_EASY *mysofa_open_cached(const char *filename, float samplerate,
                                        int *filterlength, int *err);
 void mysofa_getfilter_short(struct MYSOFA_EASY *easy, float x, float y, float z,

--- a/src/hrtf/mysofa.h
+++ b/src/hrtf/mysofa.h
@@ -127,6 +127,7 @@ enum {
 };
 
 struct MYSOFA_HRTF *mysofa_load(const char *filename, int *err);
+struct MYSOFA_HRTF *mysofa_load_data(const char *data, const int size, int *err);
 
 int mysofa_check(struct MYSOFA_HRTF *hrtf);
 char *mysofa_getAttribute(struct MYSOFA_ATTRIBUTE *attr, char *name);

--- a/src/hrtf/reader.c
+++ b/src/hrtf/reader.c
@@ -318,9 +318,8 @@ static fpos_t seekfn(void *cookie, fpos_t offset, int wense)
      errno = EINVAL;
      return -1;
    }
-   //fprintf( stderr, "cullen3 seek to position %d \n ", (int)(obj->pos) );
   
-  return 0;
+  return obj->pos;
 }
 
 MYSOFA_EXPORT struct MYSOFA_HRTF *mysofa_load_data(const char *data, const int size, int *err) {
@@ -337,11 +336,6 @@ MYSOFA_EXPORT struct MYSOFA_HRTF *mysofa_load_data(const char *data, const int s
   reader.all = NULL;
   reader.recursive_counter = 0;
 
-  //fseek( reader.fhd , 0L , SEEK_END );
-  //long csize = ftell( reader.fhd  );
-  //fprintf( stderr, "cullen2 size is %d from %d \n ", (int)csize, (int)size );
-  //fseek( reader.fhd , 0L , SEEK_SET );
-  
   *err = superblockRead(&reader, &reader.superblock);
 
   if (!*err) {

--- a/src/hrtf/reader.c
+++ b/src/hrtf/reader.c
@@ -18,8 +18,8 @@
 
 struct DATAFILE {
   const char* buf;
-  int pos;
-  int len;
+  long pos;
+  long len;
 };
 
 /* checks file address.
@@ -318,7 +318,8 @@ static fpos_t seekfn(void *cookie, fpos_t offset, int wense)
      errno = EINVAL;
      return -1;
    }
-
+   //fprintf( stderr, "cullen3 seek to position %d \n ", (int)(obj->pos) );
+  
   return 0;
 }
 
@@ -328,14 +329,19 @@ MYSOFA_EXPORT struct MYSOFA_HRTF *mysofa_load_data(const char *data, const int s
   struct DATAFILE obj;
 
   obj.buf = data;
-  obj.pos = 0;
-  obj.len = size;
+  obj.pos = 0L;
+  obj.len = (long)size;
 
   reader.fhd = funopen( (void*)(&obj), readfn, NULL, seekfn, NULL  );
   reader.gcol = NULL;
   reader.all = NULL;
   reader.recursive_counter = 0;
 
+  //fseek( reader.fhd , 0L , SEEK_END );
+  //long csize = ftell( reader.fhd  );
+  //fprintf( stderr, "cullen2 size is %d from %d \n ", (int)csize, (int)size );
+  //fseek( reader.fhd , 0L , SEEK_SET );
+  
   *err = superblockRead(&reader, &reader.superblock);
 
   if (!*err) {

--- a/src/tests/check_data.c
+++ b/src/tests/check_data.c
@@ -21,8 +21,6 @@ static void check_data(char *filename) {
   long size = ftell( fd );
   fseek( fd, 0 , SEEK_SET );
 
-  //fprintf( stderr, "cullen1 size of %s is %d \n ", filename, (int)size );
-
   char *data = malloc( size );
   int n = fread( data, 1, size, fd );
   if ( n != size ) {

--- a/src/tests/check_data.c
+++ b/src/tests/check_data.c
@@ -1,0 +1,52 @@
+#include "../hrtf/tools.h"
+#include "tests.h"
+#include <assert.h>
+#include <float.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+static void check_data(char *filename) {
+  struct MYSOFA_HRTF *hrtf;
+  int err;
+
+
+  FILE* fd =  fopen(filename, "rb");;
+  if (!fd) {
+    CU_FAIL_FATAL("Error opening file.");
+    return;
+  }
+   
+  fseek( fd, 0 , SEEK_END );
+  long size = ftell( fd );
+  fseek( fd, 0 , SEEK_SET );
+
+  //fprintf( stderr, "cullen1 size of %s is %d \n ", filename, (int)size );
+
+  char *data = malloc( size );
+  int n = fread( data, 1, size, fd );
+  if ( n != size ) {
+    CU_FAIL_FATAL("Error loading file.");
+    return;
+  }
+  
+  hrtf = mysofa_load_data( data, size, &err);
+
+  if (!hrtf) {
+    CU_FAIL_FATAL("Error reading data.");
+    return;
+  }
+
+  err = mysofa_check(hrtf);
+  CU_ASSERT(err == MYSOFA_OK);
+
+  mysofa_tocartesian(hrtf);
+
+  CU_ASSERT(err == MYSOFA_OK);
+
+  mysofa_free(hrtf);
+}
+
+void test_check_data() {
+  check_data("tests/Pulse.sofa");
+}

--- a/src/tests/external.c
+++ b/src/tests/external.c
@@ -24,6 +24,7 @@ int main() {
   /* add the tests to the suite */
   /* NOTE - ORDER IS IMPORTANT - MUST TEST fread() AFTER fprintf() */
   if ((NULL == CU_add_test(pSuite, "test of mysofa_check", test_check)) ||
+	  (NULL == CU_add_test(pSuite, "test of mysofa_check_data", test_check_data)) ||
       (NULL == CU_add_test(pSuite, "test of mysofa_lookup", test_lookup)) ||
       (NULL ==
        CU_add_test(pSuite, "test of mysofa_neighbors", test_neighbors)) ||

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -17,6 +17,8 @@ void test_nsearch();
 
 void test_check();
 
+void test_check_data();
+
 void test_lookup();
 
 void test_neighbors();


### PR DESCRIPTION
Loading from memory can make it easier when storing the HRTF as a Unity asset in iOS or Android. 

Before this is merged, it needs some work to make sure that it is not included when compiling on windows as windows does not have the funopen API which this relies on. 