### PR TITLE
Update image to Visual Studio 2022 to fix Appveyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,5 @@
 version: 1.0.{build}
+image: Visual Studio 2022
 configuration: Release
 platform: x64
 install:


### PR DESCRIPTION
I noticed the platform toolset was updated to VS 2022, but it caused Appveyor build to fail because [it was still using/expecting VS 2019](https://ci.appveyor.com/project/3DJ/libmysofa/builds/44966607):
```
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Microsoft\VC\v160\Microsoft.CppBuild.targets(439,5): 
error MSB8020: The build tools for v143 (Platform Toolset = 'v143') cannot be found. 
To build using the v143 build tools, please install v143 build tools.  
Alternatively, you may upgrade to the current Visual Studio tools by selecting the Project menu or right-click the solution, 
and then selecting "Retarget solution". [C:\projects\libmysofa\windows\libmysofa.vcxproj]
```
So specifying the VS 2022 image in .appveyor.yml [fixed the issue](https://ci.appveyor.com/project/3DJ/libmysofa/builds/44966633).