### PR TITLE
cmake: generate files in the build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,6 @@ Session.vim
 build/
 
 src/hrtf/mysofa_export.h
-src/config.h
+src/hrtf/config.h
 
 .vscode/settings.json

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,8 @@ endmacro(use_c99)
 
 use_c99()
 
-configure_file(config.h.in ${PROJECT_SOURCE_DIR}/src/config.h)
+configure_file(config.h.in config.h)
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 if(NOT MSVC)
   if(NOT WIN32)
@@ -112,7 +113,7 @@ if(BUILD_SHARED_LIBS)
                                              ${CPACK_PACKAGE_VERSION_MAJOR})
   set_property(TARGET mysofa-shared PROPERTY C_VISIBILITY_PRESET hidden)
   generate_export_header(mysofa-shared BASE_NAME mysofa EXPORT_FILE_NAME
-                         ${PROJECT_SOURCE_DIR}/src/hrtf/mysofa_export.h)
+                         mysofa_export.h)
 
   if(UNIX
      AND CODE_COVERAGE
@@ -133,7 +134,7 @@ if(BUILD_SHARED_LIBS)
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 else()
   generate_export_header(mysofa-static BASE_NAME mysofa EXPORT_FILE_NAME
-                         ${PROJECT_SOURCE_DIR}/src/hrtf/mysofa_export.h)
+                         mysofa_export.h)
 endif()
 
 install(FILES hrtf/mysofa.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/src/hrtf/reader.c
+++ b/src/hrtf/reader.c
@@ -11,7 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "../config.h"
+#include "config.h"
 #include "../hdf/reader.h"
 #include "mysofa.h"
 #include "mysofa_export.h"

--- a/windows/libmysofa.vcxproj
+++ b/windows/libmysofa.vcxproj
@@ -113,7 +113,7 @@
     </BuildLog>
     <PreBuildEvent>
       <Command>copy "..\src\hrtf\mysofa_export.h.in" "..\src\hrtf\mysofa_export.h"
-copy "config.h.sln" "..\src\config.h"</Command>
+copy "config.h.sln" "..\src\hrtf\config.h"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -156,7 +156,7 @@ copy "config.h.sln" "..\src\config.h"</Command>
     </BuildLog>
     <PreBuildEvent>
       <Command>copy "..\src\hrtf\mysofa_export.h.in" "..\src\hrtf\mysofa_export.h"
-copy "config.h.sln" "..\src\config.h"</Command>
+copy "config.h.sln" "..\src\hrtf\config.h"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
It's a good practice to keep generated files in a build directory. This patch move generated files so that source directory is not modified during the build.