### PR TITLE
Fix uninitialized error code in mysofa_open_cached

### DIFF
--- a/src/hrtf/easy.c
+++ b/src/hrtf/easy.c
@@ -139,6 +139,7 @@ MYSOFA_EXPORT struct MYSOFA_EASY *mysofa_open_cached(const char *filename,
   struct MYSOFA_EASY *res = mysofa_cache_lookup(filename, samplerate);
   if (res) {
     *filterlength = res->hrtf->N;
+    *err = MYSOFA_OK;
     return res;
   }
   res = mysofa_open(filename, samplerate, filterlength, err);


### PR DESCRIPTION
Fixes #196 

Example of workaround currently in place (from [pipewire](https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/fd03f95a3eac754bdefe290fa053f2b2ea16fea2/src/modules/module-filter-chain/builtin_plugin.c#L876-886)):

```c
	int ret = MYSOFA_OK; // <- if this is not previously set to MYSOFA_OK...

	pthread_mutex_lock(&libmysofa_mutex);
	impl->sofa = mysofa_open_cached(filename, SampleRate, &impl->n_samples, &ret);
	pthread_mutex_unlock(&libmysofa_mutex);

	if (ret != MYSOFA_OK) { // <- this will fail
		pw_log_error("Unable to load HRTF from %s: %d %m", filename, ret);
		errno = ENOENT;
		return NULL;
	}
```