### PR TITLE
Fix offset check in mysofa_seek when used in memory mode.

### DIFF
--- a/src/hrtf/reader.c
+++ b/src/hrtf/reader.c
@@ -57,7 +57,7 @@ int mysofa_seek(struct READER *reader, long offset, int whence) {
       return -1;
     }
 
-      if(offset < 0 || offset >= reader->memory_len) {
+      if(offset < 0 || offset > reader->memory_len) {
         errno = EINVAL;
         return -1;
       }


### PR DESCRIPTION
Since [f4ba5014d3202f3ecd1715e3cc8265bd9ed5585d](https://github.com/hoene/libmysofa/commit/f4ba5014d3202f3ecd1715e3cc8265bd9ed5585d), the unit test 'external' fails with the message

`libmysofa/src/tests/check_data.c:50  - CU_FAIL_FATAL("Error reading data.")`

This is caused by the check in mysofa_seek (reader.c)

`if(offset < 0 || offset >= reader->memory_len) {`

However, the call `mysofa_seek(reader, 0, SEEK_END)` (used, e.g., in `superblockRead2or3()`) invariably results in  `offset == reader->memory_len`, which appears to be correct for the end-of-file position.

Therefore I think the error check should be

`if(offset < 0 || offset > reader->memory_len) {`.

With that all unit tests are passing locally (tested on Linux and MacOS).