### PR TITLE
Implement CMake target exporting.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,3 +124,38 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/libmysofa.pc.cmake"
                "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc" @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+
+# Install exported targets as config files for use from install tree
+install(EXPORT mysofa_exports
+  NAMESPACE mysofa::
+  FILE mysofaTargets.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mysofa
+)
+
+# Create a target export file for use from the build tree.
+export(EXPORT mysofa_exports
+  NAMESPACE mysofa::
+  FILE ${CMAKE_CURRENT_BINARY_DIR}/mysofaTargets.cmake
+)
+
+include(CMakePackageConfigHelpers)
+
+# Configure package config file
+configure_package_config_file(mysofaConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/mysofaConfig.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mysofa
+)
+
+# Create package version file
+# Assuming major version bump = breaking API changes
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/mysofaConfigVersion.cmake
+  VERSION ${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}
+  COMPATIBILITY SameMajorVersion)
+
+# Install package config file for use from install tree
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/mysofaConfig.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/mysofaConfigVersion.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mysofa
+)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,22 @@ To check for memory leaks and crazy pointers
 
 > make all test
 
+### Installing
+
+Installing the library is an optional step that puts the libraries and header files into a platform-specific directory structure. This allows mysofa to be used by other projects, either using the standard directory layout of the platform or by using CMake's support for install trees.
+
+To install into the system location (e.g., `/usr/` on Linux), call
+
+> cmake install .
+
+This usually requires system administrator permissions (e.g., using `sudo`).
+
+To install to a non-system location, provide a prefix path when performing the cmake configure step:
+
+> cd build
+> cmake -DCMAKE_BUILD_TYPE=Debug .. -DCMAKE_INSTALL_PREFIX=<CMAKE_INSTALL_PREFIX>
+> make all test
+> cmake install .
 
 ## Usage
 
@@ -157,6 +173,35 @@ mysofa_close_cached(hrtf4);
 mysofa_cache_release_all();
 ```
 Then, all HRTFs having the same filename and sampling rate are stored only once in memory. If your program is using several threads, you must use appropriate synchronisation mechanisms so only a single thread can access the mysofa_open_cached and mysofa_close_cached functions at a given time.
+
+### Use libmysofa in CMake-based projects
+
+libmysofa can be imported and used as a Cmake target into other projects.
+For this, the CMake configuration of the consuming projects has to contain a statement
+
+```
+find_package( mysofa CONFIG [mysofa_version] [REQUIRED] )
+```
+
+After that, a statement
+
+```
+target_link_libraries( <target> [PRIVATE|PUBLIC] mysofa::mysofa-shared )
+```
+
+or
+
+```
+target_link_libraries( <target> [PRIVATE|PUBLIC] mysofa::mysofa-static )
+```
+
+ensures that the target `<target>` uses the respective variant of the mysofa library.
+
+In order for the `find_package` above command to work, three cases are possible:
+
+1. If mysofa has been installed to a system location, either using a package or using the `cmake install .` command introduced above, mysofa is automatically found by CMake.
+2. If mysofa has been installed to a non-system location using a `<CMAKE_INSTALL_PREFIX>` path, add the variable definition `-DCMAKE_PREFIX_PATH=<CMAKE_INSTALL_PREFIX>` to the CMake configure command of the consuming project.
+3. To use the mysofa libraries and header files of a mysofa build tree, add the variable definition `-Dmysofa_DIR=<MYSOFA_BUILD_DIRECTORY>`. When using the build instructions above, the build directory is the subdirectory `build` within the mysofa source directory.
 
 ## OS support
 

--- a/mysofaConfig.cmake.in
+++ b/mysofaConfig.cmake.in
@@ -1,0 +1,10 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+# ZLIB is a private link dependency of mysofa-static.
+find_dependency(ZLIB)
+
+include(${CMAKE_CURRENT_LIST_DIR}/mysofaTargets.cmake)
+
+check_required_components(mysofa)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,14 +76,29 @@ set(libsrc
     hrtf/easy.c
     hrtf/cache.c
     resampler/speex_resampler.c)
+
+set(public-headers
+    hrtf/mysofa.h
+)
+
 if(BUILD_STATIC_LIBS)
 add_library(mysofa-static STATIC ${libsrc})
+target_include_directories(mysofa-static
+  PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/hrtf>"
+  $<INSTALL_INTERFACE:include/>
+)
 target_link_libraries(mysofa-static LINK_PRIVATE ${MATH} ${ZLIB_LIBRARIES})
 set_target_properties(
   mysofa-static
   PROPERTIES OUTPUT_NAME mysofa CLEAN_DIRECT_OUTPUT 1 POSITION_INDEPENDENT_CODE
                                                       ${BUILD_SHARED_LIBS})
-install(TARGETS mysofa-static ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+set_target_properties( mysofa-static PROPERTIES PUBLIC_HEADER "${public-headers}" )
+install(TARGETS mysofa-static
+  EXPORT mysofa_exports
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  )
 
   if(UNIX
      AND CODE_COVERAGE
@@ -100,9 +115,19 @@ endif()
 
 if(BUILD_SHARED_LIBS)
   add_library(mysofa-shared SHARED ${libsrc})
+  target_include_directories(mysofa-shared
+    PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/hrtf>"
+    $<INSTALL_INTERFACE:include/>
+  )
   target_link_libraries(mysofa-shared PRIVATE ${MATH} ${ZLIB_LIBRARIES})
   set_target_properties(mysofa-shared
                         PROPERTIES OUTPUT_NAME mysofa CLEAN_DIRECT_OUTPUT 1)
+  # Rename the Windows import library (stub) of the DLL to prevent a name clash
+  # with the mysofa-static library.
+  set_target_properties(mysofa-shared
+                        PROPERTIES ARCHIVE_OUTPUT_NAME mysofa_shared)
+
   set_property(
     TARGET mysofa-shared
     PROPERTY
@@ -112,8 +137,12 @@ if(BUILD_SHARED_LIBS)
   set_property(TARGET mysofa-shared PROPERTY SOVERSION
                                              ${CPACK_PACKAGE_VERSION_MAJOR})
   set_property(TARGET mysofa-shared PROPERTY C_VISIBILITY_PRESET hidden)
-  generate_export_header(mysofa-shared BASE_NAME mysofa EXPORT_FILE_NAME
-                         mysofa_export.h)
+  generate_export_header(mysofa-shared
+    BASE_NAME MYSOFA
+    EXPORT_FILE_NAME mysofa_export.h
+    EXPORT_MACRO_NAME MYSOFA_EXPORT
+    STATIC_DEFINE MYSOFA_STATIC
+  )
 
   if(UNIX
      AND CODE_COVERAGE
@@ -129,15 +158,16 @@ if(BUILD_SHARED_LIBS)
 
   install(
     TARGETS mysofa-shared
+    EXPORT mysofa_exports
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  )
 else()
   generate_export_header(mysofa-static BASE_NAME mysofa EXPORT_FILE_NAME
                          mysofa_export.h)
 endif()
-
-install(FILES hrtf/mysofa.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 if(BUILD_TESTS)
   add_executable(mysofa2json tests/sofa2json.c tests/json.c)


### PR DESCRIPTION
This pull request adds exported CMake targets to libmysofa, making usage from other CMake-based projects easier.

The implementation follows the guide https://cmake.org/cmake/help/latest/guide/importing-exporting/index.html .

Added build and usage instructions to the README, please adjust or ask for amendments where needed.

Also, please change or advise on naming (e.g., the project name (mysofa) and namespace name for the exported targets (mysofa::), whether it should be capitalized, ...

Note that the change adds new files in to generated packages (e.g., .deb), this would need to be communicated to package maintainers.