### PR TITLE
Fix to accept spaces in paths of test scripts

### DIFF
--- a/tests/compare.sh
+++ b/tests/compare.sh
@@ -3,7 +3,7 @@
 SCRIPTDIR=${0%/*}
 NODEJS=$(command -v node nodejs false | head -1)
 
-${MYSOFA2JSON:-${SCRIPTDIR}/../build/src/mysofa2json} -c -o tmp1.json -s "$1".sofa 2>tmp1.txt
+"${MYSOFA2JSON:-${SCRIPTDIR}/../build/src/mysofa2json}" -c -o tmp1.json -s "$1".sofa 2>tmp1.txt
 
 ret=$?
 if [ "$ret" != 0 ]; then 

--- a/tests/compareIgnoreNew.sh
+++ b/tests/compareIgnoreNew.sh
@@ -3,7 +3,7 @@
 SCRIPTDIR=${0%/*}
 NODEJS=$(command -v node nodejs false | head -1)
 
-${MYSOFA2JSON:-${SCRIPTDIR}/../build/src/mysofa2json} -c -s -o tmp1.json "$1".sofa 2>tmp1.txt
+"${MYSOFA2JSON:-${SCRIPTDIR}/../build/src/mysofa2json}" -c -s -o tmp1.json "$1".sofa 2>tmp1.txt
 
 ret=$?
 if [ "$ret" != 0 ]; then 


### PR DESCRIPTION
I encountered failed tests when building locally. This was because the project was located under a path that included spaces. This should be fixed here by wrapping the respective path in quotation marks.