### PR TITLE
Adding declspec export attribute to header functions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -171,6 +171,12 @@ else()
                          mysofa_export.h)
 endif()
 
+# Must install export header so downstream packages can properly understand 
+# which functions are accessible
+install(FILES ${PROJECT_BINARY_DIR}/mysofa_export.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  )
+
 if(BUILD_TESTS)
   add_executable(mysofa2json tests/sofa2json.c tests/json.c)
   if(BUILD_STATIC_LIBS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -173,7 +173,7 @@ endif()
 
 # Must install export header so downstream packages can properly understand 
 # which functions are accessible
-install(FILES ${PROJECT_BINARY_DIR}/mysofa_export.h
+install(FILES ${PROJECT_BINARY_DIR}/src/mysofa_export.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   )
 

--- a/src/hrtf/mysofa.h
+++ b/src/hrtf/mysofa.h
@@ -14,15 +14,7 @@ extern "C" {
 #include <stdint.h>
 #include <stddef.h>
 
-#ifdef _WIN32
-#ifndef MYSOFA_EXPORT
-    #define MYSOFA_EXPORT __declspec(dllexport)
-#else
-    #define MYSOFA_EXPORT __declspec(dllimport)
-#endif
-#else
-  #define MYSOFA_EXPORT
-#endif
+#include "mysofa_export.h"
 
 #define MYSOFA_DEFAULT_NEIGH_STEP_ANGLE 0.5f
 #define MYSOFA_DEFAULT_NEIGH_STEP_RADIUS 0.01f

--- a/src/hrtf/mysofa.h
+++ b/src/hrtf/mysofa.h
@@ -14,6 +14,16 @@ extern "C" {
 #include <stdint.h>
 #include <stddef.h>
 
+#ifdef _WIN32
+#ifndef MYSOFA_EXPORT
+    #define MYSOFA_EXPORT __declspec(dllexport)
+#else
+    #define MYSOFA_EXPORT __declspec(dllimport)
+#endif
+#else
+  #define MYSOFA_EXPORT
+#endif
+
 #define MYSOFA_DEFAULT_NEIGH_STEP_ANGLE 0.5f
 #define MYSOFA_DEFAULT_NEIGH_STEP_RADIUS 0.01f
 
@@ -127,44 +137,44 @@ enum {
   MYSOFA_ONLY_SOURCES_WITH_MC_SUPPORTED
 };
 
-struct MYSOFA_HRTF *mysofa_load(const char *filename, int *err);
-struct MYSOFA_HRTF *mysofa_load_data(const char *data, size_t size, int *err);
+MYSOFA_EXPORT struct MYSOFA_HRTF *mysofa_load(const char *filename, int *err);
+MYSOFA_EXPORT struct MYSOFA_HRTF *mysofa_load_data(const char *data, size_t size, int *err);
 
-int mysofa_check(struct MYSOFA_HRTF *hrtf);
-char *mysofa_getAttribute(struct MYSOFA_ATTRIBUTE *attr, char *name);
-void mysofa_tospherical(struct MYSOFA_HRTF *hrtf);
-void mysofa_tocartesian(struct MYSOFA_HRTF *hrtf);
-void mysofa_free(struct MYSOFA_HRTF *hrtf);
+MYSOFA_EXPORT int mysofa_check(struct MYSOFA_HRTF *hrtf);
+MYSOFA_EXPORT char *mysofa_getAttribute(struct MYSOFA_ATTRIBUTE *attr, char *name);
+MYSOFA_EXPORT void mysofa_tospherical(struct MYSOFA_HRTF *hrtf);
+MYSOFA_EXPORT void mysofa_tocartesian(struct MYSOFA_HRTF *hrtf);
+MYSOFA_EXPORT void mysofa_free(struct MYSOFA_HRTF *hrtf);
 
-struct MYSOFA_LOOKUP *mysofa_lookup_init(struct MYSOFA_HRTF *hrtf);
-int mysofa_lookup(struct MYSOFA_LOOKUP *lookup, float *coordinate);
-void mysofa_lookup_free(struct MYSOFA_LOOKUP *lookup);
+MYSOFA_EXPORT struct MYSOFA_LOOKUP *mysofa_lookup_init(struct MYSOFA_HRTF *hrtf);
+MYSOFA_EXPORT int mysofa_lookup(struct MYSOFA_LOOKUP *lookup, float *coordinate);
+MYSOFA_EXPORT void mysofa_lookup_free(struct MYSOFA_LOOKUP *lookup);
 
-struct MYSOFA_NEIGHBORHOOD *
+MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *
 mysofa_neighborhood_init(struct MYSOFA_HRTF *hrtf,
                          struct MYSOFA_LOOKUP *lookup);
-struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init_withstepdefine(
+MYSOFA_EXPORT struct MYSOFA_NEIGHBORHOOD *mysofa_neighborhood_init_withstepdefine(
     struct MYSOFA_HRTF *hrtf, struct MYSOFA_LOOKUP *lookup,
     float neighbor_angle_step, float neighbor_radius_step);
-int *mysofa_neighborhood(struct MYSOFA_NEIGHBORHOOD *neighborhood, int pos);
-void mysofa_neighborhood_free(struct MYSOFA_NEIGHBORHOOD *neighborhood);
+MYSOFA_EXPORT int *mysofa_neighborhood(struct MYSOFA_NEIGHBORHOOD *neighborhood, int pos);
+MYSOFA_EXPORT void mysofa_neighborhood_free(struct MYSOFA_NEIGHBORHOOD *neighborhood);
 
-float *mysofa_interpolate(struct MYSOFA_HRTF *hrtf, float *cordinate,
+MYSOFA_EXPORT float *mysofa_interpolate(struct MYSOFA_HRTF *hrtf, float *cordinate,
                           int nearest, int *neighborhood, float *fir,
                           float *delays);
 
-int mysofa_resample(struct MYSOFA_HRTF *hrtf, float samplerate);
-float mysofa_loudness(struct MYSOFA_HRTF *hrtf);
-int mysofa_minphase(struct MYSOFA_HRTF *hrtf, float threshold);
+MYSOFA_EXPORT int mysofa_resample(struct MYSOFA_HRTF *hrtf, float samplerate);
+MYSOFA_EXPORT float mysofa_loudness(struct MYSOFA_HRTF *hrtf);
+MYSOFA_EXPORT int mysofa_minphase(struct MYSOFA_HRTF *hrtf, float threshold);
 
-struct MYSOFA_EASY *mysofa_cache_lookup(const char *filename, float samplerate);
-struct MYSOFA_EASY *mysofa_cache_store(struct MYSOFA_EASY *,
+MYSOFA_EXPORT struct MYSOFA_EASY *mysofa_cache_lookup(const char *filename, float samplerate);
+MYSOFA_EXPORT struct MYSOFA_EASY *mysofa_cache_store(struct MYSOFA_EASY *,
                                        const char *filename, float samplerate);
-void mysofa_cache_release(struct MYSOFA_EASY *);
-void mysofa_cache_release_all(void);
+MYSOFA_EXPORT void mysofa_cache_release(struct MYSOFA_EASY *);
+MYSOFA_EXPORT void mysofa_cache_release_all(void);
 
-void mysofa_c2s(float values[3]);
-void mysofa_s2c(float values[3]);
+MYSOFA_EXPORT void mysofa_c2s(float values[3]);
+MYSOFA_EXPORT void mysofa_s2c(float values[3]);
 
 struct MYSOFA_EASY {
   struct MYSOFA_HRTF *hrtf;
@@ -173,38 +183,38 @@ struct MYSOFA_EASY {
   float *fir;
 };
 
-struct MYSOFA_EASY *mysofa_open(const char *filename, float samplerate,
+MYSOFA_EXPORT struct MYSOFA_EASY *mysofa_open(const char *filename, float samplerate,
                                 int *filterlength, int *err);
-struct MYSOFA_EASY *mysofa_open_no_norm(const char *filename, float samplerate,
+MYSOFA_EXPORT struct MYSOFA_EASY *mysofa_open_no_norm(const char *filename, float samplerate,
                                         int *filterlength, int *err);
-struct MYSOFA_EASY *mysofa_open_advanced(const char *filename, float samplerate,
+MYSOFA_EXPORT struct MYSOFA_EASY *mysofa_open_advanced(const char *filename, float samplerate,
                                          int *filterlength, int *err, bool norm,
                                          float neighbor_angle_step,
                                          float neighbor_radius_step);
-struct MYSOFA_EASY *mysofa_open_data(const char *data, long size,
+MYSOFA_EXPORT struct MYSOFA_EASY *mysofa_open_data(const char *data, long size,
                                      float samplerate, int *filterlength,
                                      int *err);
-struct MYSOFA_EASY *mysofa_open_data_no_norm(const char *data, long size,
+MYSOFA_EXPORT struct MYSOFA_EASY *mysofa_open_data_no_norm(const char *data, long size,
                                              float samplerate,
                                              int *filterlength, int *err);
-struct MYSOFA_EASY *mysofa_open_data_advanced(
+MYSOFA_EXPORT struct MYSOFA_EASY *mysofa_open_data_advanced(
     const char *data, long size, float samplerate, int *filterlength, int *err,
     bool norm, float neighbor_angle_step, float neighbor_radius_step);
-struct MYSOFA_EASY *mysofa_open_cached(const char *filename, float samplerate,
+MYSOFA_EXPORT struct MYSOFA_EASY *mysofa_open_cached(const char *filename, float samplerate,
                                        int *filterlength, int *err);
-void mysofa_getfilter_short(struct MYSOFA_EASY *easy, float x, float y, float z,
+MYSOFA_EXPORT void mysofa_getfilter_short(struct MYSOFA_EASY *easy, float x, float y, float z,
                             short *IRleft, short *IRright, int *delayLeft,
                             int *delayRight);
-void mysofa_getfilter_float(struct MYSOFA_EASY *easy, float x, float y, float z,
+MYSOFA_EXPORT void mysofa_getfilter_float(struct MYSOFA_EASY *easy, float x, float y, float z,
                             float *IRleft, float *IRright, float *delayLeft,
                             float *delayRight);
-void mysofa_getfilter_float_nointerp(struct MYSOFA_EASY *easy, float x, float y,
+MYSOFA_EXPORT void mysofa_getfilter_float_nointerp(struct MYSOFA_EASY *easy, float x, float y,
                                      float z, float *IRleft, float *IRright,
                                      float *delayLeft, float *delayRight);
-void mysofa_close(struct MYSOFA_EASY *easy);
-void mysofa_close_cached(struct MYSOFA_EASY *easy);
+MYSOFA_EXPORT void mysofa_close(struct MYSOFA_EASY *easy);
+MYSOFA_EXPORT void mysofa_close_cached(struct MYSOFA_EASY *easy);
 
-void mysofa_getversion(int *major, int *minor, int *patch);
+MYSOFA_EXPORT void mysofa_getversion(int *major, int *minor, int *patch);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Hi there! I'm trying to get libmysofa added to vcpkg so it will be available to more users. Also steam-audio uses libmysofa and I'd like to use steam-audio from vcpkg :smile:

See: https://github.com/microsoft/vcpkg/pull/38368

For my vcpkg port I ran into an interesting problem that this patch addresses. Without this any downstream project that depends on libmysofa will fail to properly link to the library on windows. Not sure if this is the way you'd like to fix this. We could also do a .def file for the linker to mark these functions as part of the export .lib.