### PR TITLE
Safe limit increase

### DIFF
--- a/src/hdf/btree.c
+++ b/src/hdf/btree.c
@@ -266,8 +266,8 @@ int treeRead(struct READER *reader, struct DATAOBJECT *data) {
 
   mylog("elements %d size %d\n", elements, size);
 
-if(elements <= 0 || size <= 0 || elements > INT_MAX/size)
-  return MYSOFA_INVALID_FORMAT; // LCOV_EXCL_LINE
+  if(elements <= 0 || size <= 0 || elements > INT_MAX/size)
+    return MYSOFA_INVALID_FORMAT; // LCOV_EXCL_LINE
   if (!(output = malloc(elements * size))) {
     return MYSOFA_NO_MEMORY; // LCOV_EXCL_LINE
   }

--- a/src/hdf/btree.c
+++ b/src/hdf/btree.c
@@ -266,7 +266,7 @@ int treeRead(struct READER *reader, struct DATAOBJECT *data) {
 
   mylog("elements %d size %d\n", elements, size);
 
-  if(elements <= 0 || size <= 0 || elements > INT_MAX/size)
+  if (elements <= 0 || size <= 0 || elements > INT_MAX/size)
     return MYSOFA_INVALID_FORMAT; // LCOV_EXCL_LINE
   if (!(output = malloc(elements * size))) {
     return MYSOFA_NO_MEMORY; // LCOV_EXCL_LINE

--- a/src/hdf/btree.c
+++ b/src/hdf/btree.c
@@ -266,8 +266,8 @@ int treeRead(struct READER *reader, struct DATAOBJECT *data) {
 
   mylog("elements %d size %d\n", elements, size);
 
-  if (elements <= 0 || size <= 0 || elements >= 0x130000 || size > 0x10)
-    return MYSOFA_INVALID_FORMAT; // LCOV_EXCL_LINE
+//if (elements <= 0 || size <= 0 || elements >= 0x130000 || size > 0x10)
+//  return MYSOFA_INVALID_FORMAT; // LCOV_EXCL_LINE
   if (!(output = malloc(elements * size))) {
     return MYSOFA_NO_MEMORY; // LCOV_EXCL_LINE
   }

--- a/src/hdf/btree.c
+++ b/src/hdf/btree.c
@@ -266,8 +266,8 @@ int treeRead(struct READER *reader, struct DATAOBJECT *data) {
 
   mylog("elements %d size %d\n", elements, size);
 
-//if (elements <= 0 || size <= 0 || elements >= 0x130000 || size > 0x10)
-//  return MYSOFA_INVALID_FORMAT; // LCOV_EXCL_LINE
+if(elements <= 0 || size <= 0 || INT_MAX/size > elements)
+  return MYSOFA_INVALID_FORMAT; // LCOV_EXCL_LINE
   if (!(output = malloc(elements * size))) {
     return MYSOFA_NO_MEMORY; // LCOV_EXCL_LINE
   }

--- a/src/hdf/btree.c
+++ b/src/hdf/btree.c
@@ -266,7 +266,7 @@ int treeRead(struct READER *reader, struct DATAOBJECT *data) {
 
   mylog("elements %d size %d\n", elements, size);
 
-if(elements <= 0 || size <= 0 || INT_MAX/size > elements)
+if(elements <= 0 || size <= 0 || elements > INT_MAX/size)
   return MYSOFA_INVALID_FORMAT; // LCOV_EXCL_LINE
   if (!(output = malloc(elements * size))) {
     return MYSOFA_NO_MEMORY; // LCOV_EXCL_LINE


### PR DESCRIPTION
I've seen many reports of users having issues loading even moderately-sized SOFAs in software that uses libmysofa, due to the current limit. Even for OpenAL Soft's makemhr converter I had to use my fork where I removed the limit, but [the dev suggested a better, safer alternative](https://github.com/kcat/openal-soft/pull/1026#issuecomment-2268680856) which I figured I'd share here in case it's a viable option:

> Looks like it may need an overflow check too. Something like
```c++
if(elements <= 0 || size <= 0 || elements > INT_MAX/size)
  return MYSOFA_INVALID_FORMAT;
  ```
> I don't know how this check in specific relates to the file or dataset size, but at least the result of `elements * size` can't go far above 2.1 billion, or else it'll overflow and become undefined behavior. Expanding that would need more work to avoid signed ints, where those kinds of changes tend to need farther reaching changes since those variables may interact with other variables that may not be happy when they're different types.