### PR TITLE
minor testscripts improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ if(BUILD_TESTS)
 )
     # issues with osx    96)
     add_test(NAME fail-issue-${ISSUE} COMMAND ${PROJECT_SOURCE_DIR}/tests/notcrashed.sh
-             ${PROJECT_SOURCE_DIR}/tests/fail-issue-${ISSUE})
+             ${PROJECT_SOURCE_DIR}/tests/fail-issue-${ISSUE} $<TARGET_FILE:mysofa2json>)
   endforeach(ISSUE)
   add_test(NAME CIPIC_subject_003_hrir_final COMMAND ${PROJECT_SOURCE_DIR}/tests/compare.sh
            ${PROJECT_SOURCE_DIR}/tests/CIPIC_subject_003_hrir_final $<TARGET_FILE:mysofa2json>)

--- a/tests/compare.sh
+++ b/tests/compare.sh
@@ -1,30 +1,51 @@
 #!/bin/sh
 
-mysofa2json=$2
+usage() {
+    cat >/dev/stderr <<EOF
+usage: $0 <sofafile> [<mysofa2json>]
+
+  <sofafile>: SOFA file (without the .sofa extension) to test
+  <mysofa2json>: 'mysofa2json' executable
+
+the test expects a <sofafile>.json.bz2 reference file,
+which is compared against the output of mysofa2json.
+
+$*
+EOF
+    exit 1
+}
+
+sofafile="${1}.sofa"
+referencefile="${1}.json.bz2"
+mysofa2json="${2:-../build/src/mysofa2json}"
+
+test -n "$1" || usage
+test -e "${sofafile}" || usage "No such file: '${sofafile}'"
+test -e "${referencefile}" || usage "No such file: '${referencefile}'"
+test -x "${mysofa2json}" || usage "No mysofa2json executable: '${mysofa2json}'"
 
 SCRIPTDIR=${0%/*}
 NODEJS=$(command -v node nodejs false | head -1)
-TMP1=`mktemp -p . tmp1-XXXXXXXX.json`
-TMP2=`mktemp -p . tmp2-XXXXXXXX.txt`
-TMP3=`mktemp -p . tmp3-XXXXXXXX.json`
+TMP1="$(mktemp -p . tmp1-XXXXXXXX.json)"
+TMP2="$(mktemp -p . tmp2-XXXXXXXX.txt)"
+TMP3="$(mktemp -p . tmp3-XXXXXXXX.json)"
 
-"$mysofa2json" -c -o "$TMP1" -s "$1".sofa 2>"$TMP2"
+"${mysofa2json}" -c -o "$TMP1" -s "${sofafile}" 2>"$TMP2"
 
 ret=$?
-if [ "$ret" != 0 ]; then 
+if [ "$ret" != 0 ]; then
     cat "$TMP2"
     echo Error libmysofa $ret
     exit $ret
 fi
 
 cp -f "${SCRIPTDIR}/json-diff.js" . 2>/dev/null || true
-bunzip2 -c -k "$1".json.bz2 >"$TMP3"
+bunzip2 -c -k "${referencefile}" >"$TMP3"
 "${NODEJS}" ./json-diff.js "$TMP1" "$TMP3"
 ret=$?
-if [ "$ret" != 0 ]; then 
+if [ "$ret" != 0 ]; then
     echo Diff $ret
     exit $ret
 fi
 echo ok
 rm "$TMP1" "$TMP2" "$TMP3"
-

--- a/tests/compareIgnoreNew.sh
+++ b/tests/compareIgnoreNew.sh
@@ -1,29 +1,51 @@
 #!/bin/sh
-mysofa2json=$2
+
+usage() {
+    cat >/dev/stderr <<EOF
+usage: $0 <sofafile> [<mysofa2json>]
+
+  <sofafile>: SOFA file (without the .sofa extension) to test
+  <mysofa2json>: 'mysofa2json' executable
+
+the test expects a <sofafile>.json.bz2 reference file,
+which is compared against the output of mysofa2json.
+
+$*
+EOF
+    exit 1
+}
+
+sofafile="${1}.sofa"
+referencefile="${1}.json.bz2"
+mysofa2json="${2:-../build/src/mysofa2json}"
+
+test -n "$1" || usage
+test -e "${sofafile}" || usage "No such file: '${sofafile}'"
+test -e "${referencefile}" || usage "No such file: '${referencefile}'"
+test -x "${mysofa2json}" || usage "No mysofa2json executable: '${mysofa2json}'"
 
 SCRIPTDIR=${0%/*}
 NODEJS=$(command -v node nodejs false | head -1)
-TMP1=`mktemp -p . tmp1-XXXXXXXX.json`
-TMP2=`mktemp -p . tmp2-XXXXXXXX.txt`
-TMP3=`mktemp -p . tmp3-XXXXXXXX.json`
+TMP1="$(mktemp -p . tmp1-XXXXXXXX.json)"
+TMP2="$(mktemp -p . tmp2-XXXXXXXX.txt)"
+TMP3="$(mktemp -p . tmp3-XXXXXXXX.json)"
 
-"$mysofa2json" -c -s -o "$TMP1" "$1".sofa 2>"$TMP2"
+"$mysofa2json" -c -s -o "$TMP1" "${sofafile}" 2>"$TMP2"
 
 ret=$?
-if [ "$ret" != 0 ]; then 
+if [ "$ret" != 0 ]; then
     cat "$TMP2"
     echo Error libmysofa $ret
     exit $ret
 fi
 
 cp -f "${SCRIPTDIR}/json-diffIgnoreNew.js" . 2>/dev/null || true
-bunzip2 -c -k "$1".json.bz2 >"$TMP3"
+bunzip2 -c -k "${referencefile}" >"$TMP3"
 "${NODEJS}" ./json-diffIgnoreNew.js "$TMP1" "$TMP3"
 ret=$?
-if [ "$ret" != 0 ]; then 
+if [ "$ret" != 0 ]; then
     echo Diff $ret
     exit $ret
 fi
 echo ok
 rm "$TMP1" "$TMP2" "$TMP3"
-

--- a/tests/notcrashed.sh
+++ b/tests/notcrashed.sh
@@ -1,11 +1,31 @@
 #!/bin/sh
-test -f "$1".sofa || exit 128
-../build/src/mysofa2json -c "$1".sofa >/dev/null 2>/dev/null
+usage() {
+    cat >/dev/stderr <<EOF
+usage: $0 <sofafile> [<mysofa2json>]
+
+  <sofafile>: SOFA file (without the .sofa extension) to test
+  <mysofa2json>: 'mysofa2json' executable
+
+tests whether <sofafile>.sofa can be loaded without crashing.
+
+$*
+EOF
+    exit 1
+}
+
+sofafile="${1}.sofa"
+mysofa2json="${2:-../build/src/mysofa2json}"
+
+#test -e "${sofafile}" || usage "No such file: '${sofafile}'"
+test -n "${1}" || usage
+test -f "${sofafile}" || exit 128
+test -x "${mysofa2json}" || usage "No mysofa2json executable: '${mysofa2json}'"
+
+"${mysofa2json}" -c "${sofafile}" >/dev/null 2>/dev/null
 ret=$?
 if [ "$ret" -ge 128 ]; then
-	    echo mysofa2json crashed with $ret opening$1.sofa
-            exit $ret
+    echo mysofa2json crashed with $ret opening '${sofafile}'
+    exit $ret
 fi
 echo good
 exit 0
-


### PR DESCRIPTION
- use the same interface for all test wrappers (`tests/*.sh`): `<scriptname> <testfile-without-extension> [<mysofa2json>]`
- improve argument check, and print usage information if the test-scripts are called with the wrong args
- consistent indentation and removed trailing whitespace
- pass the path to `mysofa2json` to the `tests/nocrash.sh` script as well (like for the other wrappers)


- Related: https://github.com/hoene/libmysofa/issues/243