### PR TITLE
more CI tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,25 @@ on:
   workflow_dispatch:
 
 jobs:
+  CommitInfo:
+    # proudust/gh-describe@v2 might be useful, but provides neither date nor absolute count
+    runs-on: ubuntu-latest
+    outputs:
+      date: ${{ steps.ghd.outputs.Date }}
+      hash: ${{ steps.ghd.outputs.Hash }}
+      count: ${{ steps.ghd.outputs.Count }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Get current date, commit hash and count
+        id: ghd
+        run: |
+          echo "Date=$(git show -s --date=format:'%Y-%m-%d' --format=%cd)" | tee -a $GITHUB_OUTPUT
+          echo "Hash=$(git rev-parse --short=7 HEAD)" | tee -a $GITHUB_OUTPUT
+          echo "Count=$(git rev-list --count HEAD)" | tee -a $GITHUB_OUTPUT
 
   Linux:
     runs-on: ubuntu-latest
@@ -36,16 +55,13 @@ jobs:
 
   Windows:
     runs-on: windows-latest
+    needs:
+      - CommitInfo
     steps:
-
     - name: Clone repo and submodules
-      run: git clone --recurse-submodules https://github.com/${{github.repository}}.git . --branch ${{env.Branch}}
-
-    - name: Get current date, commit hash and count
-      run: |
-        echo "CommitDate=$(git show -s --date=format:'%Y-%m-%d' --format=%cd)" >> $env:GITHUB_ENV
-        echo "CommitHashShort=$(git rev-parse --short=7 HEAD)" >> $env:GITHUB_ENV
-        echo "CommitCount=$(git rev-list --count HEAD)" >> $env:GITHUB_ENV
+      uses: actions/checkout@v6
+      with:
+        submodules: true
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2
@@ -57,7 +73,7 @@ jobs:
     - name: Upload Installer Artifact to GitHub
       uses: actions/upload-artifact@v4
       with:
-        name: "${{github.event.repository.name}}_r${{env.CommitCount}}@${{env.CommitHashShort}}"
+        name: "${{github.event.repository.name}}_r${{needs.CommitInfo.outputs.count}}@${{needs.CommitInfo.outputs.hash}}"
         path: "${{github.workspace}}/${{env.Artifacts}}/"
 
     - name: GitHub pre-release
@@ -66,5 +82,5 @@ jobs:
         repo_token: "${{secrets.GITHUB_TOKEN}}"
         automatic_release_tag: "latest"
         prerelease: true
-        title: "[${{env.CommitDate}}] ${{github.event.repository.name}} r${{env.CommitCount}}@${{env.CommitHashShort}}"
+        title: "[${{needs.CommitInfo.outputs.date}}] ${{github.event.repository.name}} r${{needs.CommitInfo.outputs.count}}@${{needs.CommitInfo.outputs.hash}}"
         files: "${{env.Artifacts}}/*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,6 @@ jobs:
     runs-on: windows-latest
     needs:
       - CommitInfo
-      - Linux
     steps:
     - name: Clone repo and submodules
       uses: actions/checkout@v6
@@ -75,7 +74,17 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: "${{github.event.repository.name}}_r${{needs.CommitInfo.outputs.count}}@${{needs.CommitInfo.outputs.hash}}"
-        path: "${{github.workspace}}/${{env.Artifacts}}/"
+        path: "${{ github.workspace }}/${{ env.Artifacts }}/"
+
+  PreRelease:
+    runs-on: ubuntu-latest
+    needs:
+      - CommitInfo
+      - Windows
+      - Linux
+    steps:
+    - name: Fetch artifacts
+      uses: actions/download-artifact@v5
 
     - name: GitHub pre-release
       uses: "marvinpinto/action-automatic-releases@latest"
@@ -84,4 +93,4 @@ jobs:
         automatic_release_tag: "latest"
         prerelease: true
         title: "[${{needs.CommitInfo.outputs.date}}] ${{github.event.repository.name}} r${{needs.CommitInfo.outputs.count}}@${{needs.CommitInfo.outputs.hash}}"
-        files: "${{env.Artifacts}}/*"
+        files: "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ env:
   Solution: windows/libmysofa.sln
   Configuration: Release
   Artifacts: windows/bin/x64/Release
-  
+
 on:
   push:
     Branches: $Branch
@@ -14,6 +14,26 @@ on:
   workflow_dispatch:
 
 jobs:
+
+  Linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: sudo apt-get install -y zlib1g-dev libcunit1-dev
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Build Project
+        id: build
+        uses: threeal/cmake-action@v2.1.0
+        with:
+          build-dir: _build
+      - name: Run tests
+        run: cmake --build ${{ steps.build.outputs.build-dir }} -t test
+
   Windows:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,7 @@ jobs:
     runs-on: windows-latest
     needs:
       - CommitInfo
+      - Linux
     steps:
     - name: Clone repo and submodules
       uses: actions/checkout@v6


### PR DESCRIPTION
in the wake of https://github.com/hoene/libmysofa/issues/243 i decided that it is probably best to run the test-suite on the CI, so we can catch issues here early.

this PR attempts to implement this:
- it adds a new job `Linux` that builds libmysofa and *runs the tests*
- it splits the existing `Windows` job into:
  - a `CommitInfo` job that extracts the information for the release version
  - the `Windows` job that only builds libmysofa and generates some artifacts
  - a `PreRelease` job that creates a pre-release and attaches the Windows-artifacts to it.

in my fork of the project, the `PreRelease` step fails, but that was also the case in the original `Windows` job, so I don't think this is a regression (but couldn't actually test)