### PR TITLE
fix: replace bzero with memset

### DIFF
--- a/src/tests/cache.c
+++ b/src/tests/cache.c
@@ -15,8 +15,8 @@ void test_cache() {
 
   struct MYSOFA_EASY *easy1 = malloc(sizeof(struct MYSOFA_EASY));
   struct MYSOFA_EASY *easy2 = malloc(sizeof(struct MYSOFA_EASY));
-  bzero(easy1, sizeof(struct MYSOFA_EASY));
-  bzero(easy2, sizeof(struct MYSOFA_EASY));
+  memset(easy1, 0, sizeof(struct MYSOFA_EASY));
+  memset(easy2, 0, sizeof(struct MYSOFA_EASY));
 
   mysofa_close(easy2); /* must pass without segfail */
 
@@ -36,20 +36,20 @@ void test_cache() {
    */
 
   easy1 = malloc(sizeof(struct MYSOFA_EASY));
-  bzero(easy1, sizeof(struct MYSOFA_EASY));
+  memset(easy1, 0, sizeof(struct MYSOFA_EASY));
 
   CU_ASSERT(mysofa_cache_store(easy1, filename1, sr1) == easy1); /* add again */
 
   easy2 = malloc(
       sizeof(struct MYSOFA_EASY)); /* easy2 has been freed automatically */
-  bzero(easy2, sizeof(struct MYSOFA_EASY));
+  memset(easy2, 0, sizeof(struct MYSOFA_EASY));
 
   CU_ASSERT(mysofa_cache_store(easy2, filename1, sr1) ==
             easy1); /* second add must be possible too, return cached */
 
   easy2 = malloc(
       sizeof(struct MYSOFA_EASY)); /* easy2 has been freed automatically */
-  bzero(easy2, sizeof(struct MYSOFA_EASY));
+  memset(easy2, 0, sizeof(struct MYSOFA_EASY));
 
   CU_ASSERT(mysofa_cache_store(easy2, filename1, sr2) ==
             easy2); /* now third add with different sample rate */
@@ -60,7 +60,7 @@ void test_cache() {
   CU_ASSERT(!mysofa_cache_lookup(filename1, sr2));
 
   easy2 = malloc(sizeof(struct MYSOFA_EASY));
-  bzero(easy2, sizeof(struct MYSOFA_EASY));
+  memset(easy2, 0, sizeof(struct MYSOFA_EASY));
 
   CU_ASSERT(mysofa_cache_store(easy2, filename2, sr2) ==
             easy2); /* now third add with different file name */


### PR DESCRIPTION
bzero has been removed in POSIX.1-2008, and isn't provided by platforms like MinGW-w64